### PR TITLE
修复：OAuth DCR 客户端注册表持久化，避免容器重启后客户端失效

### DIFF
--- a/src/web/oauth.py
+++ b/src/web/oauth.py
@@ -90,6 +90,44 @@ def _mcp_tokens_file() -> str:
     return os.path.join(sh.config["buckets_dir"], ".dashboard_mcp_tokens.json")
 
 
+def _oauth_clients_file() -> str:
+    return os.path.join(sh.config["buckets_dir"], ".oauth_clients.json")
+
+
+def _load_oauth_clients() -> None:
+    """启动时恢复 DCR 客户端注册表。
+
+    注册表若不持久化，容器重启后客户端（Claude Desktop 经 mcp-remote 等）
+    缓存的 client_id 会变成 unknown client_id，授权页 400 无限循环，
+    用户只能手动清客户端缓存才能恢复。与 token 同策略落盘 buckets 卷。"""
+    global _oauth_clients
+    try:
+        path = _oauth_clients_file()
+        if not os.path.exists(path):
+            return
+        with open(path, "r", encoding="utf-8") as f:
+            raw = _json_lib.load(f)
+        if isinstance(raw, dict):
+            _oauth_clients = {
+                cid: info for cid, info in raw.items()
+                if isinstance(cid, str) and isinstance(info, dict)
+            }
+    except Exception as e:
+        logger.warning(f"[oauth] failed to load oauth clients: {e}")
+
+
+def _save_oauth_clients() -> None:
+    try:
+        path = _oauth_clients_file()
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        tmp = path + ".tmp"
+        with open(tmp, "w", encoding="utf-8") as f:
+            _json_lib.dump(_oauth_clients, f, ensure_ascii=False)
+        os.replace(tmp, path)
+    except Exception as e:
+        logger.warning(f"[oauth] failed to save oauth clients: {e}")
+
+
 def _load_mcp_tokens() -> None:
     global _mcp_tokens, _mcp_token_resources, _mcp_refresh_tokens
     try:
@@ -298,6 +336,7 @@ button:hover{{background:#d4b87a}}
 def register(mcp) -> None:
     """注册 /.well-known/* 与 /oauth/* 路由，并在装配时载入持久化 token。"""
     _load_mcp_tokens()   # 启动时恢复持久化 token，Docker 重启不再强制重新 OAuth
+    _load_oauth_clients()  # 启动时恢复 DCR 客户端注册表，重启后旧 client_id 依然有效
 
     @mcp.custom_route("/.well-known/oauth-protected-resource", methods=["GET"])
     @mcp.custom_route("/.well-known/oauth-protected-resource/{resource_path:path}", methods=["GET"])
@@ -342,7 +381,9 @@ def register(mcp) -> None:
         _oauth_clients[client_id] = {
             "redirect_uris": body.get("redirect_uris", []),
             "client_name": body.get("client_name", "MCP Client"),
+            "registered_at": int(_time_mod.time()),
         }
+        _save_oauth_clients()
         return JSONResponse({
             "client_id": client_id,
             "client_id_issued_at": int(_time_mod.time()),


### PR DESCRIPTION
你好，感谢开发这个项目，我是不懂代码的普通用户，日常靠它给 Claude 记忆。以下问题是我实际使用中遇到、由 Claude（Fable 5）排查定位并修复的，我确认过修复在自己的部署上有效，想借这个机会把信息共享回来。文字和代码都出自 AI 之手，如有不妥之处请多包涵，欢迎随意修改或用你自己的方式实现。

## 问题描述

当前 oauth.py 中动态客户端注册（DCR）的注册表 `_oauth_clients` 为纯内存字典，容器重启后清空。已通过 DCR 注册的客户端（如 Claude Desktop 经 mcp-remote 接入）重启后携带旧 client_id 请求授权时，会收到 unknown client_id 400 错误，表现为授权页无限循环，用户无法自行恢复，只能清除客户端缓存重新注册。access/refresh token 已有落盘机制，但没有客户端身份的持久化，token 持久化的价值也随之打折。

## 复现步骤

1. 客户端通过 `/oauth/register` 完成 DCR 并授权成功
2. 重启容器
3. 同一客户端携带原 client_id 请求 `/oauth/authorize`，返回 400 unknown client_id

## 修复方案

仿照现有 token 落盘模式，将客户端注册表原子写入 JSON 文件（`<buckets_dir>/.oauth_clients.json`），注册时保存，启动时随 token 一起加载。改动集中在 oauth.py，新增三个函数，不改变任何现有接口行为。

## 验证

注册测试客户端 → 授权校验通过 → 重启容器 → 同一 client_id 授权校验依然通过（修复前必现 400）。仓库自带的 `test_oauth_refresh_token.py` 与 `test_security_regression.py` 在改动后全部通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
