### PR TITLE
fix: Ollama `:latest` 标签导致同一 embedding 模型被误判不一致（假 OB-W005）

### DIFF
--- a/src/embedding_engine.py
+++ b/src/embedding_engine.py
@@ -88,8 +88,11 @@ def _norm_model(name: str) -> str:
     Gemini OpenAI-compat 端点要求 "models/" 前缀，OpenAI 兼容代理（aihubmix /
     硅基流动等）用裸名——同一模型仅前缀不同。剥掉前缀 + 去空白 + 小写，
     让 model_name 的对账只看真实身份，不被书写约定误伤（修 OB-W005 假阳性）。
+    Ollama 的 ":latest" 是默认 tag：bge-m3 与 bge-m3:latest 是同一模型，
+    比较前剥掉结尾 ":latest"。仅剥这一个 tag——:q4_0 之类量化 tag 代表
+    不同的量化版本，是真实身份差异，不能剥。
     """
-    return strip_native_resource_prefix(name).lower()
+    return strip_native_resource_prefix(name).lower().removesuffix(":latest")
 
 
 def _humanize_api_error(e: Exception) -> str:

--- a/tests/test_comprehensive.py
+++ b/tests/test_comprehensive.py
@@ -1149,3 +1149,15 @@ class TestEmbeddingModelNorm:
     def test_different_models_stay_distinct(self):
         from embedding_engine import _norm_model
         assert _norm_model("bge-m3") != _norm_model("gemini-embedding-001")
+
+    def test_latest_tag_equivalent_to_bare(self):
+        from embedding_engine import _norm_model
+        # Ollama 的 :latest 默认 tag vs 裸名 → 同一模型（假 OB-W005 场景）
+        assert _norm_model("bge-m3:latest") == _norm_model("bge-m3")
+        assert _norm_model("BGE-M3:latest") == _norm_model("bge-m3")
+
+    def test_quantization_tags_stay_distinct(self):
+        from embedding_engine import _norm_model
+        # 非 :latest 的 tag 是不同量化版本，必须保持可区分
+        assert _norm_model("bge-m3:q4_0") != _norm_model("bge-m3")
+        assert _norm_model("bge-m3:q4_0") != _norm_model("bge-m3:latest")


### PR DESCRIPTION
你好！又是我 😄 这个 PR 由 AI（Claude）排查并修复，我本人做了确认。

**问题**：用 Ollama 跑 embedding 时，`bge-m3` 和 `bge-m3:latest` 是同一个模型（`:latest` 只是 Ollama 补上的默认 tag），但 `_norm_model()` 归一化时只剥 `models/` 前缀，两种写法会被 `_check_meta_consistency` 判为模型不一致，触发假 OB-W005 并提示跑全量 migrate。配置里写裸名、而历史 meta 存了带 tag 的名字（或反过来）时必现。

**修复**：归一化时把结尾的 `:latest` 一并剥掉。只剥这一个 tag——`bge-m3:q4_0` 之类代表不同量化版本，是真实身份差异，保持区分。实质相同、只是写法不同的情况会走已有的「顺手升级 meta 写法」路径，之后不再重复对账。

**测试**：在 `TestEmbeddingModelNorm` 里补了 `:latest` 等价和量化 tag 区分两个用例，连同原有 3 个用例全部通过。

感谢维护这个项目！有任何想调整的地方请随时告诉我。

🤖 Generated with [Claude Code](https://claude.com/claude-code)