### PR TITLE
Add gateway MCP credential

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,6 +44,12 @@ TUNNEL_TRANSPORT_PROTOCOL=http2
 # 设置后 Dashboard 页面会要求输入密码才能访问。
 # OMBRE_DASHBOARD_PASSWORD=change-me
 
+# ---- Gateway machine credential (optional, recommended for an LLM gateway) ----
+# Keep MCP OAuth enabled for people/Claude clients. Set the same long random
+# value in the gateway's OMBRE_GATEWAY_API_KEY; the gateway sends it in the
+# X-Ombre-Gateway-Key header. This is not the Dashboard password.
+# OMBRE_GATEWAY_API_KEY=replace-with-a-long-random-value
+
 # ---- Hooks / HTTP 钩子鉴权（可选）------------------------------
 # /breath-hook 和 /dream-hook 默认不再公开；可使用 Dashboard 登录态或设置 token。
 # 调用方式：?token=... 或请求头 X-Ombre-Hook-Token: ... / Authorization: Bearer ...

--- a/src/server_app.py
+++ b/src/server_app.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import hmac
 import json
 import os
 from contextlib import asynccontextmanager
@@ -98,7 +99,12 @@ def _request_resource(scope: Mapping[str, Any], headers: Mapping[bytes, bytes]) 
 
 
 class MCPAuthMiddleware:
-    """Require an OAuth bearer token for the streamable MCP endpoint."""
+    """Require OAuth or a dedicated gateway credential for ``/mcp``.
+
+    Human MCP clients keep using Ombre's OAuth flow. A separately configured
+    gateway may use ``X-Ombre-Gateway-Key`` for server-to-server access, so it
+    never needs the Dashboard password and OAuth does not need to be disabled.
+    """
 
     def __init__(
         self,
@@ -111,14 +117,22 @@ class MCPAuthMiddleware:
         self.auth_required = bool(auth_required)
         self.token_validator = token_validator
 
+    @staticmethod
+    def _gateway_key_is_valid(headers: Mapping[bytes, bytes]) -> bool:
+        """Validate the optional machine credential without accepting blanks."""
+        configured = os.environ.get("OMBRE_GATEWAY_API_KEY", "").strip()
+        supplied = headers.get(b"x-ombre-gateway-key", b"").decode("latin-1").strip()
+        return bool(configured and supplied and hmac.compare_digest(supplied, configured))
+
     async def __call__(self, scope: dict, receive: Any, send: Any) -> None:
         path = str(scope.get("path", ""))
         if scope.get("type") == "http" and self.auth_required and path.startswith("/mcp"):
             headers = {key.lower(): value for key, value in scope.get("headers", [])}
             auth = headers.get(b"authorization", b"").decode("latin-1")
             resource, base = _request_resource(scope, headers)
-            valid = auth.startswith("Bearer ") and self.token_validator(
-                auth[7:], resource=resource
+            valid = self._gateway_key_is_valid(headers) or (
+                auth.startswith("Bearer ")
+                and self.token_validator(auth[7:], resource=resource)
             )
             if not valid:
                 endpoint = path.strip("/")

--- a/tests/test_server_app.py
+++ b/tests/test_server_app.py
@@ -185,6 +185,56 @@ async def test_auth_middleware_validates_token_against_exact_resource():
 
 
 @pytest.mark.asyncio
+async def test_auth_middleware_accepts_only_the_configured_gateway_key(monkeypatch):
+    monkeypatch.setenv("OMBRE_GATEWAY_API_KEY", "gateway-secret")
+    downstream = RecordingASGIApp()
+    middleware = MCPAuthMiddleware(
+        downstream,
+        auth_required=True,
+        token_validator=lambda *_args, **_kwargs: False,
+    )
+    scope = {
+        "type": "http",
+        "scheme": "https",
+        "path": "/mcp",
+        "headers": [
+            (b"host", b"ombre.example"),
+            (b"x-ombre-gateway-key", b"gateway-secret"),
+        ],
+    }
+
+    await middleware(scope, _empty_receive, _discard_send)
+
+    assert downstream.scopes == [scope]
+
+
+@pytest.mark.asyncio
+async def test_auth_middleware_rejects_an_incorrect_gateway_key(monkeypatch):
+    monkeypatch.setenv("OMBRE_GATEWAY_API_KEY", "gateway-secret")
+    downstream = RecordingASGIApp()
+    middleware = MCPAuthMiddleware(
+        downstream,
+        auth_required=True,
+        token_validator=lambda *_args, **_kwargs: False,
+    )
+    messages = []
+    scope = {
+        "type": "http",
+        "scheme": "https",
+        "path": "/mcp",
+        "headers": [
+            (b"host", b"ombre.example"),
+            (b"x-ombre-gateway-key", b"wrong-key"),
+        ],
+    }
+
+    await middleware(scope, _empty_receive, _collect_into(messages))
+
+    assert downstream.scopes == []
+    assert messages[0]["status"] == 401
+
+
+@pytest.mark.asyncio
 async def test_auth_middleware_can_be_explicitly_disabled():
     downstream = RecordingASGIApp()
     middleware = MCPAuthMiddleware(


### PR DESCRIPTION
Add a dedicated machine credential for the LLM gateway to access Ombre MCP.

- keeps OAuth enabled for normal MCP clients
- avoids using the Ombre Dashboard password in the gateway
- adds acceptance and rejection tests