### PR TITLE
fix: STDIO 启动成功后重置 boot marker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,17 @@
   文件不在 index 也不在 HEAD 时直接报错，不再拿工作区字节顶替。
 - 发布顺序固定为：先 `git add` 代码改动，再生成清单——清单描述的是仓库内容，
   不是磁盘内容。
+- 修复 STDIO transport 成功启动后 `.boot_fails` 未重置：HTTP/SSE 通过
+  `RuntimeLifecycle` 在成功启动后清零，STDIO 原先直接调用 `mcp.run()` 缺少对应
+  lifecycle；现改为在 FastMCP public lifespan 成功进入时复用现有 boot marker reset 语义。
 
 ### 测试 / Tests
 
 - 新增 `tests/test_update_manifest_repo_bytes.py`：用临时 git 仓库复现
   「index 存 LF / 工作区 CRLF」与「index 存 CRLF」两种会被算错的形态，
   并校验仓库现有清单与 HEAD 字节逐条一致。
+- 新增真实 STDIO MCP 子进程回归：完成 `initialize` 与 `tools/list`（15 个工具）后，
+  验证 `.boot_fails` 从 1 重置为 0。
 
 ### 版本 / Version
 

--- a/src/server.py
+++ b/src/server.py
@@ -32,6 +32,7 @@ import sys
 import logging
 import asyncio
 import time
+from contextlib import asynccontextmanager
 from typing import Optional, Awaitable
 import httpx
 
@@ -321,12 +322,31 @@ _gh_auto_interval: int = int(_gh_cfg.get("auto_interval_minutes") or 0)
 # 远程 Streamable HTTP 固定返回单个 JSON-RPC 对象，并且不要求客户端在
 # initialize 后保存/回传 Mcp-Session-Id。Kelivo 等会静默吞掉 tools/list 异常的
 # 客户端因此不会再出现“已连接但 0 工具”。stdio 与 legacy SSE 不受这两项影响。
+
+_stdio_runtime_lifecycle = None
+
+
+@asynccontextmanager
+async def _stdio_lifespan(_server):
+    lifecycle = _stdio_runtime_lifecycle
+    if lifecycle is None:
+        yield {}
+        return
+
+    await lifecycle.start()
+    try:
+        yield {}
+    finally:
+        await lifecycle.stop()
+
+
 mcp = FastMCP(
     "Ombre Brain",
     host=_BIND_HOST,
     port=OMBRE_PORT,
     json_response=True,
     stateless_http=True,
+    lifespan=_stdio_lifespan if config.get("transport", "stdio") == "stdio" else None,
 )
 
 
@@ -1256,5 +1276,13 @@ if __name__ == "__main__":
             proxy_headers=False,
         )
     else:
-        # stdio：15 个工具已直接注册在唯一 mcp 实例上，这里直接运行即可。
+        # stdio：15 个工具已直接注册在唯一 mcp 实例上；启动成功边界由
+        # FastMCP public lifespan 触发，复用 RuntimeLifecycle 的 boot marker 语义。
+        _stdio_runtime_lifecycle = RuntimeLifecycle(
+            logger=logger,
+            boot_marker_path=os.path.join(
+                os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                ".boot_fails",
+            ),
+        )
         mcp.run(transport=transport)

--- a/tests/test_server_app.py
+++ b/tests/test_server_app.py
@@ -1,6 +1,9 @@
 import asyncio
 import json
+import shutil
+import sys
 from contextlib import asynccontextmanager
+from pathlib import Path
 from types import SimpleNamespace
 
 import httpx
@@ -1202,3 +1205,51 @@ def test_build_http_app_rejects_stdio_transport():
             token_validator=lambda *_args, **_kwargs: False,
             lifecycle=RuntimeLifecycle(logger=RecordingLogger()),
         )
+
+
+@pytest.mark.asyncio
+async def test_stdio_mcp_server_resets_existing_boot_marker_after_successful_handshake(
+    tmp_path,
+):
+    from mcp import ClientSession, StdioServerParameters
+    from mcp.client.stdio import stdio_client
+
+    runtime_root = tmp_path / "runtime"
+    shutil.copytree(Path(__file__).resolve().parents[1] / "src", runtime_root / "src")
+    shutil.copy(Path(__file__).resolve().parents[1] / "VERSION", runtime_root / "VERSION")
+
+    buckets_dir = tmp_path / "buckets"
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        json.dumps(
+            {
+                "transport": "stdio",
+                "buckets_dir": str(buckets_dir),
+                "embedding": {"enabled": False},
+            }
+        ),
+        encoding="utf-8",
+    )
+    marker = runtime_root / ".boot_fails"
+    marker.write_text("1\n", encoding="utf-8")
+
+    server = StdioServerParameters(
+        command=sys.executable,
+        args=[str(runtime_root / "src" / "server.py")],
+        cwd=runtime_root,
+        env={
+            "OMBRE_CONFIG_PATH": str(config_path),
+            "OMBRE_BUCKETS_DIR": str(buckets_dir),
+            "OMBRE_LOG_DIR": str(tmp_path / "logs"),
+            "PYTHONPYCACHEPREFIX": str(tmp_path / "pycache"),
+        },
+    )
+
+    async with stdio_client(server) as (read_stream, write_stream):
+        async with ClientSession(read_stream, write_stream) as session:
+            initialized = await session.initialize()
+            listed = await session.list_tools()
+
+    assert initialized.protocolVersion
+    assert [tool.name for tool in listed.tools] == list(EXPECTED_PUBLIC_MCP_TOOLS)
+    assert marker.read_text(encoding="utf-8") == "0"


### PR DESCRIPTION
## 问题

官方 entrypoint 启动前会递增 `.boot_fails`。HTTP/SSE 会在
`RuntimeLifecycle.start()` 成功后清零，但 STDIO 原先直接
`mcp.run()`，因此成功启动、完成 MCP `initialize` / `tools/list`
后 marker 仍可能保持为 `1`。

## 修复

- STDIO 使用 FastMCP public lifespan 作为成功启动生命周期边界；
- 复用现有 `RuntimeLifecycle` 的 boot marker reset 语义；
- STDIO lifecycle 仅注入 `logger` 与 `boot_marker_path`，
  不启动 HTTP 路径的后台服务；
- HTTP/SSE 行为不变。

## 回归

- 新增真实 STDIO MCP 子进程测试；
- 完成 `initialize` 与 `tools/list`（15 个工具）后，
  验证 `.boot_fails` 从 `1` 重置为 `0`；
- 目标回归：1 passed；
- `tests/test_server_app.py` 排除当前执行环境无法本地监听的既有 SSE 用例后：
  71 passed, 1 deselected；
- `git diff --check` clean。

已同步更新 2.13.1 CHANGELOG，未修改版本号。

署名：wudy29