### PR TITLE
feat(hold): support optional domain override

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -751,14 +751,15 @@ async def hold(
     meaning: Optional[str] = "",
     media: Optional[list | str] = None,
     test_data: Optional[bool] = False,
+    domain: Optional[str] = "",
 ) -> str:
-    """仅在对话中已明确决定“这段内容值得成为长期记忆”时调用；不要因普通聊天、猜测或工具名称联想而自行调用。content 逐字保存，绝不压缩。title 可选；传入时是最终显式标题，优先于打标模型建议。系统自动补其余元数据，API 不可用时使用本地中性值继续保存。tags 逗号分隔，importance 1-10。pinned=True 标记为永久核心；feel=True 存为感受类记忆。source_bucket 是正在消化的原始记忆桶 ID。why_remembered 与 meaning 是可选的第一人称记录原因。media 可传服务器可读路径或 data_base64+filename 列表项。"""
+    """仅在对话中已明确决定“这段内容值得成为长期记忆”时调用；不要因普通聊天、猜测或工具名称联想而自行调用。content 逐字保存，绝不压缩。title 可选；传入时是最终显式标题，优先于打标模型建议。domain 可选、逗号分隔；显式传入时优先于打标模型结果。系统自动补其余元数据，API 不可用时使用本地中性值继续保存。tags 逗号分隔，importance 1-10。pinned=True 标记为永久核心；feel=True 存为感受类记忆且 domain 固定为 feel。source_bucket 是正在消化的原始记忆桶 ID。why_remembered 与 meaning 是可选的第一人称记录原因。media 可传服务器可读路径或 data_base64+filename 列表项。"""
     return await _with_notice(
         _t_hold.dispatch(
             content=content, title=title, tags=tags, importance=importance,
             pinned=pinned, feel=feel, source_bucket=source_bucket,
             valence=valence, arousal=arousal, why_remembered=why_remembered,
-            meaning=meaning, media=media, test_data=test_data,
+            meaning=meaning, media=media, test_data=test_data, domain=domain,
         ),
         op="hold",
         args={
@@ -768,6 +769,7 @@ async def hold(
             "why_len": len(why_remembered or ""), "meaning_len": len(meaning or ""),
             "media_count": len(media or []),
             "test_data": bool(test_data),
+            "domain": domain,
         },
     )
 

--- a/src/tools/hold/__init__.py
+++ b/src/tools/hold/__init__.py
@@ -17,7 +17,7 @@ core（普通存入 + 自动合并）。
 - 不返回结构化数据，统一返回供模型阅读的中文短句
 
 对外暴露：dispatch(content, tags, importance, pinned, feel, source_bucket,
-                   valence, arousal, why_remembered, meaning, media) → str
+                   valence, arousal, why_remembered, meaning, media, domain) → str
 ========================================
 """
 
@@ -36,6 +36,15 @@ from .pinned import store_pinned
 from .core import store_core
 
 
+def _normalize_explicit_domain(value: str | list[str] | None) -> list[str] | None:
+    if isinstance(value, list):
+        parts = [str(item).strip() for item in value if item is not None]
+    else:
+        parts = [item.strip() for item in str(value or "").split(",")]
+    normalized = list(dict.fromkeys(item for item in parts if item))
+    return normalized or None
+
+
 async def dispatch(
     content: str,
     title: Optional[str] = "",
@@ -50,6 +59,7 @@ async def dispatch(
     meaning: Optional[str] = "",
     media: Optional[list | str] = None,
     test_data: Optional[bool] = False,
+    domain: Optional[str | list[str]] = "",
 ) -> str:
     content = "" if content is None else str(content)
     try:
@@ -76,9 +86,12 @@ async def dispatch(
     if meaning is None:
         meaning = ""
     meaning = str(meaning).strip()
+    explicit_domain = _normalize_explicit_domain(domain)
     test_data = parse_bool(test_data, default=False)
     if test_data and (pinned or feel):
         return "测试数据不能创建为 pinned 或 feel；请使用普通测试桶。"
+    if feel and explicit_domain:
+        return "feel 的 domain 固定为 feel，不能显式覆盖。"
     try:
         importance = int(importance)
     except (TypeError, ValueError, OverflowError):
@@ -98,6 +111,7 @@ async def dispatch(
         source_bucket=source_bucket,
         why_remembered=why_remembered,
         meaning=meaning,
+        domain=domain,
     )
     if metadata_err:
         return metadata_err
@@ -191,6 +205,7 @@ async def dispatch(
             why_remembered=why_remembered,
             meaning=meaning,
             media=media,
+            explicit_domain=explicit_domain,
         )
         return result
 
@@ -205,5 +220,6 @@ async def dispatch(
         meaning=meaning,
         media=media,
         test_data=test_data,
+        explicit_domain=explicit_domain,
     )
     return result

--- a/src/tools/hold/core.py
+++ b/src/tools/hold/core.py
@@ -44,6 +44,7 @@ async def store_core(
     meaning: str = "",
     media: list | str | None = None,
     test_data: bool = False,
+    explicit_domain: list[str] | None = None,
 ) -> str:
     metadata_fallback = False
     try:
@@ -63,9 +64,10 @@ async def store_core(
             "suggested_name": "",
         }
 
-    domain = analysis.get("domain") or ["未分类"]
-    if not isinstance(domain, list):
-        domain = ["未分类"]
+    analyzed_domain = analysis.get("domain") or ["未分类"]
+    if not isinstance(analyzed_domain, list):
+        analyzed_domain = ["未分类"]
+    final_domain = explicit_domain or analyzed_domain
     _v = analysis.get("valence", 0.5)
     _a = analysis.get("arousal", 0.3)
     final_valence = valence if 0 <= valence <= 1 else (float(_v) if _v is not None else 0.5)
@@ -80,7 +82,7 @@ async def store_core(
         content=content,
         tags=all_tags,
         importance=importance,
-        domain=domain,
+        domain=final_domain,
         valence=final_valence,
         arousal=final_arousal,
         name=suggested_name,
@@ -97,7 +99,7 @@ async def store_core(
     asyncio.create_task(check_plan_resolution(content, source_bucket_id=result_name))
     if not is_merged:
         asyncio.create_task(check_duplicate_for(result_name, content))
-    result = f"{action}{result_name} {','.join(str(d) for d in domain if d is not None)}"
+    result = f"{action}{result_name} {','.join(str(d) for d in final_domain if d is not None)}"
     if embed_warn:
         result += f"\n⚠️ {embed_warn}"
     if metadata_fallback:

--- a/src/tools/hold/pinned.py
+++ b/src/tools/hold/pinned.py
@@ -37,6 +37,7 @@ async def store_pinned(
     title: str = "",
     meaning: str = "",
     media: list | None = None,
+    explicit_domain: list[str] | None = None,
 ) -> str:
     try:
         analysis = await rt.dehydrator.analyze(content)
@@ -47,9 +48,10 @@ async def store_pinned(
             "tags": [], "suggested_name": "",
         }
 
-    domain = analysis.get("domain") or ["未分类"]
-    if not isinstance(domain, list):
-        domain = ["未分类"]
+    analyzed_domain = analysis.get("domain") or ["未分类"]
+    if not isinstance(analyzed_domain, list):
+        analyzed_domain = ["未分类"]
+    final_domain = explicit_domain or analyzed_domain
     _v = analysis.get("valence", 0.5)
     _a = analysis.get("arousal", 0.3)
     final_valence = valence if 0 <= valence <= 1 else (float(_v) if _v is not None else 0.5)
@@ -71,7 +73,7 @@ async def store_pinned(
             content=content,
             tags=all_tags,
             importance=10,
-            domain=domain,
+            domain=final_domain,
             valence=final_valence,
             arousal=final_arousal,
             name=suggested_name or None,
@@ -93,4 +95,4 @@ async def store_pinned(
             content_changed=True,
             meaning_changed=bool(meaning),
         )
-    return f"📌钉选→{bucket_id} {','.join(str(d) for d in domain if d is not None)}"
+    return f"📌钉选→{bucket_id} {','.join(str(d) for d in final_domain if d is not None)}"

--- a/tests/test_mcp_tools_docker_integration.py
+++ b/tests/test_mcp_tools_docker_integration.py
@@ -91,6 +91,7 @@ EXPECTED_TOOL_PROPERTIES = {
         "meaning",
         "media",
         "test_data",
+        "domain",
     },
     "grow": {"content", "items", "test_data"},
     "source_read": {"bucket_id", "expected_title", "scope", "cursor", "max_tokens"},

--- a/tests/test_memory_boundary_regressions.py
+++ b/tests/test_memory_boundary_regressions.py
@@ -128,9 +128,18 @@ async def test_hold_analysis_failure_preserves_exact_content(monkeypatch):
     )
 
     assert captured["content"] == original
+    assert captured["domain"] == ["未分类"]
     assert captured["raw_merge"] is True
     assert captured["source_tool"] == "hold"
     assert "正文已逐字保存，未做任何压缩" in result
+
+    captured.clear()
+    await hold_core.store_core(
+        original, extra_tags=[], importance=5,
+        valence=-1, arousal=-1, why_remembered="",
+        explicit_domain=["人工域"],
+    )
+    assert captured["domain"] == ["人工域"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_quota_race_regression.py
+++ b/tests/test_quota_race_regression.py
@@ -73,6 +73,24 @@ async def test_concurrent_hold_pinned_does_not_exceed_cap(bucket_mgr, monkeypatc
 
 
 @pytest.mark.asyncio
+async def test_store_pinned_explicit_domain_overrides_analysis(bucket_mgr):
+    install_runtime(bucket_mgr)
+
+    result = await store_pinned(
+        content="显式 pinned domain",
+        extra_tags=[],
+        valence=0.5,
+        arousal=0.3,
+        why_remembered="",
+        explicit_domain=["人工域"],
+    )
+
+    bucket_id = result.split("→", 1)[1].split()[0]
+    bucket = await bucket_mgr.get(bucket_id)
+    assert bucket["metadata"]["domain"] == ["人工域"]
+
+
+@pytest.mark.asyncio
 async def test_concurrent_trace_protect_does_not_exceed_independent_cap(bucket_mgr):
     install_runtime(bucket_mgr, limits={"max_protected": 3})
 

--- a/tests/test_source_layer.py
+++ b/tests/test_source_layer.py
@@ -253,6 +253,41 @@ async def test_hold_explicit_tags_replace_model_suggestions(
 
 
 @pytest.mark.asyncio
+async def test_hold_explicit_domain_wins_over_model_suggestion(
+    bucket_mgr, monkeypatch
+):
+    class Dehydrator:
+        async def analyze(self, _content):
+            return {
+                "domain": ["模型域"],
+                "valence": 0.5,
+                "arousal": 0.3,
+                "tags": [],
+                "suggested_name": "模型标题",
+            }
+
+        def invalidate_cache(self, _content):
+            return None
+
+    class Decay:
+        async def ensure_started(self):
+            return None
+
+    monkeypatch.setattr(rt, "config", {"limits": {}, "merge_threshold": 75})
+    monkeypatch.setattr(rt, "bucket_mgr", bucket_mgr)
+    monkeypatch.setattr(rt, "dehydrator", Dehydrator())
+    monkeypatch.setattr(rt, "decay_engine", Decay())
+    monkeypatch.setattr(rt, "logger", MagicMock())
+    monkeypatch.setattr(rt, "fire_webhook", None)
+    monkeypatch.setattr(rt, "mark_op", None)
+
+    result = await hold(content="人工 domain 优先。", domain="人工域")
+    bucket_id = result.split("→", 1)[1].split()[0]
+    bucket = await bucket_mgr.get(bucket_id)
+    assert bucket["metadata"]["domain"] == ["人工域"]
+
+
+@pytest.mark.asyncio
 async def test_title_over_limit_is_rejected_before_hold_writes(bucket_mgr, monkeypatch):
     class Decay:
         async def ensure_started(self):

--- a/tests/test_v3_legacy_tool_entrypoints.py
+++ b/tests/test_v3_legacy_tool_entrypoints.py
@@ -51,6 +51,50 @@ async def test_hold_dispatch_records_v3_tool_event_without_content_body(monkeypa
 
 
 @pytest.mark.asyncio
+async def test_hold_dispatch_normalizes_and_forwards_domain(monkeypatch) -> None:
+    captured = {}
+
+    async def fake_store_core(**kwargs):
+        captured.update(kwargs)
+        return "hold result"
+
+    rt.init(config={}, decay_engine=_Decay(), mark_op=None)
+    monkeypatch.setattr(hold_mod, "check_content_size", lambda _content: None)
+    monkeypatch.setattr(hold_mod, "store_core", fake_store_core)
+
+    result = await hold_mod.dispatch(
+        content="domain memory",
+        domain=" 工作, 生活,工作 ",
+    )
+
+    assert result == "hold result"
+    assert captured["explicit_domain"] == ["工作", "生活"]
+
+
+@pytest.mark.asyncio
+async def test_hold_rejects_explicit_domain_for_feel(monkeypatch) -> None:
+    called = False
+
+    async def fake_store_feel(**_kwargs):
+        nonlocal called
+        called = True
+        return "unexpected"
+
+    rt.init(config={}, decay_engine=_Decay(), mark_op=None)
+    monkeypatch.setattr(hold_mod, "store_feel", fake_store_feel)
+
+    result = await hold_mod.dispatch(
+        content="feel memory",
+        feel=True,
+        source_bucket="source-1",
+        domain="生活",
+    )
+
+    assert result == "feel 的 domain 固定为 feel，不能显式覆盖。"
+    assert called is False
+
+
+@pytest.mark.asyncio
 async def test_trace_core_records_v3_tool_event_without_content_body(monkeypatch) -> None:
     calls = []
 


### PR DESCRIPTION
## Motivation

`hold` currently rejects explicit `domain` input, which prevents callers from guiding memory categorization.

## Changes

- Add optional `domain` parameter to `hold`
- Support explicit domain override over analyzer output
- Preserve existing automatic domain analysis behavior when `domain` is omitted
- Keep `feel` memories using the fixed `feel` domain

## Tests

- Targeted tests passed
- Full test suite: 2143 passed, 100 skipped
- Remaining failures are unrelated to this change:
  - backup archive migration tests (existing target files)
  - macOS subprocess encoding issue (CI runs on Linux)