### PR TITLE
fix: require explicit plan resolution

### DIFF
--- a/docs/INTERNALS.md
+++ b/docs/INTERNALS.md
@@ -400,7 +400,7 @@ feel 桶自身：
 
 **严格字符串去重**：登记前扫描所有 `status="active"` 的 plan 桶，若存在 `content` 与新内容**完全字符串相等**的桶，直接返回原 ID 不重复创建（避免重复 `plan("还没回邮件")` 刷屏）。
 
-**自动结案机制**：每次 `hold()` 或 `grow()` 末尾 `asyncio.create_task(_check_plan_resolution())` —— 向量预筛（>0.7）→ LLM 双判 (`resolved && confidence >= 0.7`) → 写 `status="resolved"` + `resolution_reason` + `resolved_by`。任何异常都吞掉，不影响主流程。无 embedding 时整个机制跳过（保守，宁漏报不误报）。
+**完成建议机制**：每次 `hold()` 或 `grow()` 末尾 `asyncio.create_task(_check_plan_resolution())`。系统只把关键词/BM25 或向量（>0.7）实际召回的 active plan 交给 LLM；当 `resolved && confidence >= 0.7` 时写入 `resolution_suggested`（理由、信心、来源与时间），status 仍保持 `active`。实际关闭只能由 `trace(status="resolved")` 或 Dashboard action 显式完成。任何异常都吞掉，不影响主流程；无 embedding 时仍使用关键词/BM25 召回。
 
 ### 3.8 `letter_write` / `letter_read` / `letter_lock_update` — 信件
 
@@ -1521,7 +1521,7 @@ normalized = total / w_sum × 100   # 归一化到 0~100
 | `0.2` | `breath` 检索 | 情感重构系数 `(q_v - 0.5) × 0.2`，最大 ±0.1 |
 | `3` / `0.4` / `2.0` / `1~3` | `breath` 检索 | 随机漂浮触发条件 / 概率 / 池阈值 / 数量 |
 | `30` 字符 | `grow` | 短内容快速路径阈值 |
-| `0.7` | `_check_plan_resolution` | plan 自动结案向量预筛 |
+| `0.7` | `_check_plan_resolution` | plan 完成建议的向量预筛 |
 | `0.7` | dream | feel 结晶相似度阈值 |
 | `0.5` | dream | 连接提示相似度阈值 |
 | `10` | dream | 取最近 N 条 |
@@ -1563,7 +1563,7 @@ normalized = total / w_sum × 100   # 归一化到 0~100
 | `trace` 无字段变更 | — | 返回「没有任何字段需要修改。」 |
 | `dehydrator.dehydrate` API 不可用 | `api_available=False` | 不影响 breath；正文返回阶段不再调用 dehydrator |
 | `embedding.search_similar` 未启用 | enabled=False | 返回 `[]`，调用方 fallback |
-| `_check_plan_resolution` 无 embedding | — | 整体跳过（保守，不误报） |
+| `_check_plan_resolution` 无 embedding | — | 退回关键词/BM25 召回；未命中就不交给 LLM |
 | `decay_cycle` list_all 失败 | 异常 | 返回 `{checked:0, error:str}`，不终止后台循环 |
 | `decay_cycle` 单桶评分失败 | 异常 | WARNING 日志，跳过该桶 |
 

--- a/src/bucket_manager.py
+++ b/src/bucket_manager.py
@@ -2135,13 +2135,20 @@ class BucketManager:
             updates = dict(kwargs)
             if append_plan_history and str(post.get("type") or "") == "plan":
                 history = list(post.get("change_log") or [])
-                if "status" in updates and updates["status"] != post.get("status"):
+                old_status = post.get("status") or "active"
+                if "status" in updates and updates["status"] != old_status:
                     history = append_plan_change_log(
                         history,
                         "status",
-                        **{"from": post.get("status"), "to": updates["status"]},
+                        **{
+                            "from": old_status,
+                            "to": updates["status"],
+                            "by": event_actor,
+                        },
                     )
-                updates["change_log"] = append_plan_change_log(history, "edit")
+                updates["change_log"] = append_plan_change_log(
+                    history, "edit", by=event_actor
+                )
             updates["content"] = updated_content
             try:
                 committed = await self._update_locked(

--- a/src/bucket_manager.py
+++ b/src/bucket_manager.py
@@ -2484,6 +2484,7 @@ class BucketManager:
         # iter 1.7 §G3 在这里加入了 "change_log"——plan 桶的状态/编辑历史 list[dict]，
         # 由 server.py 的 plan() / trace() / /api/plans/{id}/action 维护，bucket_manager 不参与生成。
         for k in ("status", "type", "resolution_reason", "resolved_by",
+                  "resolution_suggested",
                   "related_bucket", "author", "user_name", "letter_date",
                   "lock_type", "unlock_date", "locked_by", "lock_owner_source", "writer_name",
                   "change_log",

--- a/src/server.py
+++ b/src/server.py
@@ -979,7 +979,7 @@ async def plan(
     weight: Optional[float] = 0.5,
     why_remembered: Optional[str] = "",
 ) -> str:
-    """登记一个待办/承诺/未闭环事项。status=active(默认)/resolved/abandoned。related_bucket 可选,关联到某个普通记忆桶。weight=承诺重量 0.0-1.0(默认 0.5),与 importance 区分——importance 表示「多重要」、weight 表示「多重」。why_remembered=登记原因(可选、仅展示)。plan 不衰减、不出现在普通 breath,仅在 dream 末尾的 active 段返回;后续 hold/grow 写入新事件时系统自动判断已登记的 plan 是否完成。"""
+    """登记一个待办/承诺/未闭环事项。status=active(默认)/resolved/abandoned。related_bucket 可选,关联到某个普通记忆桶。weight=承诺重量 0.0-1.0(默认 0.5),与 importance 区分——importance 表示「多重要」、weight 表示「多重」。why_remembered=登记原因(可选、仅展示)。plan 不衰减、不出现在普通 breath,仅在 dream 末尾的 active 段返回;后续 hold/grow 写入新事件时系统只会提示可能已完成,实际关闭必须显式调用 trace(status="resolved")。"""
     return await _with_notice(
         _t_plan.plan_create(
             content=content, status=status, related_bucket=related_bucket,

--- a/src/tools/_common.py
+++ b/src/tools/_common.py
@@ -6,7 +6,7 @@ tools/_common.py — 跨工具共享的辅助逻辑
 这个文件收纳被多个工具同时复用的、与具体工具语义无关的小工具：
 配额检查（单桶字节上限 / pinned/protected 数量上限）、
 合并或新建（hold/grow 共用）、
-新桶疑似重复扫描、新事件触发的 plan 自动闭环判定。
+新桶疑似重复扫描、新事件触发的 plan 完成建议判定。
 
 关键行为：
 - check_content_size / check_pinned_quota / check_protected_quota：读取
@@ -16,8 +16,8 @@ tools/_common.py — 跨工具共享的辅助逻辑
 - iter 2.0：merge_or_create 接受 ``source_tool`` / ``grow_batch_id``，
   新建时写入 frontmatter；合并时不动原桶 source_tool，只追加 ``last_merged_by``
 - check_duplicate_for：fire-and-forget 标记疑似重复对（不自动合并）
-- check_plan_resolution：fire-and-forget 用关键词/向量双通道预筛 + LLM 保守判断
-  来把已完成的 active plan 标为 resolved
+- check_plan_resolution：fire-and-forget 用关键词/向量双通道预筛 + LLM 保守判断，
+  只记录可能已完成的建议，保留 active 状态等待显式确认
 
 不做什么（边界）：
 - 不持有任何全局对象，所有依赖都从 _runtime 取
@@ -41,7 +41,7 @@ import math
 import threading
 
 from bucket_manager import _filesystem_turn as _kernel_filesystem_turn
-from utils import normalize_memory_title, parse_bool
+from utils import normalize_memory_title, now_iso, parse_bool
 from ombrebrain.domain.plan_history import append_plan_change_log as append_plan_change_log
 
 from . import _runtime as rt
@@ -1324,7 +1324,7 @@ async def _rank_active_plans_by_query(
 
 
 async def check_plan_resolution(new_event_text: str, source_bucket_id: str = "") -> None:
-    """新事件触发 active plan 关键词/向量召回，再由 LLM 保守判断是否闭环。"""
+    """新事件只检查检索命中的 active plan，并把 LLM 结果记录为建议。"""
     try:
         from .plan.core import is_letter_bucket
 
@@ -1354,7 +1354,7 @@ async def check_plan_resolution(new_event_text: str, source_bucket_id: str = "")
         # 小模型调用数，避免 active plan 很多时一次写入触发无界 API 请求。
         plan_candidates = []
         seen_plan_ids: set[str] = set()
-        for candidate in keyword_candidates + vector_candidates + active_plans:
+        for candidate in keyword_candidates + vector_candidates:
             candidate_id = str(candidate.get("id") or "")
             if not candidate_id or candidate_id in seen_plan_ids:
                 continue
@@ -1367,15 +1367,21 @@ async def check_plan_resolution(new_event_text: str, source_bucket_id: str = "")
                 judgement = await rt.dehydrator.judge_plan_resolution(
                     p["content"], new_event_text
                 )
-                if judgement.get("resolved") and judgement.get("confidence", 0.0) >= _PLAN_LLM_CONFIDENCE_MIN:
+                confidence = float(judgement.get("confidence") or 0.0)
+                if judgement.get("resolved") and confidence >= _PLAN_LLM_CONFIDENCE_MIN:
+                    reason = str(judgement.get("reason") or "")[:_RESOLUTION_REASON_MAX]
                     await rt.bucket_mgr.update(
                         p["id"],
-                        status="resolved",
-                        resolution_reason=judgement.get("reason", "")[:_RESOLUTION_REASON_MAX],
-                        resolved_by=source_bucket_id or "",
+                        resolution_suggested={
+                            "reason": reason,
+                            "confidence": confidence,
+                            "suggested_by": "plan_resolution_judge",
+                            "source_bucket_id": source_bucket_id or "",
+                            "ts": now_iso(),
+                        },
                     )
                     rt.logger.info(
-                        f"plan auto-resolved: {p['id']} — {judgement.get('reason', '')[:_LOG_REASON_PREVIEW]}"
+                        f"plan resolution suggested: {p['id']} — {reason[:_LOG_REASON_PREVIEW]}"
                     )
             except Exception as e:
                 rt.logger.warning(f"plan resolution judgement failed for {p['id']}: {e}")
@@ -1391,8 +1397,8 @@ async def check_plan_resolution(new_event_text: str, source_bucket_id: str = "")
 # 这是 rule.md §1 哲学落地：plan 是承诺，承诺被放下，承载这条承诺
 # 的事件桶也不该再浮上来。
 #
-# 不联动的路径：check_plan_resolution（LLM 自动二判）—— 自动判定
-# 的可信度低于人工/AI 显式动作，避免把活的事件桶意外打沉。
+# check_plan_resolution（LLM 自动二判）只写 resolution_suggested，
+# 不改变 plan status，因此也不会进入这条联动路径。
 #
 # 反向不做：bucket trace(resolved=1) 不联动 plan（plan 是独立承诺，
 # 单条事件结束不等于承诺达成）。

--- a/src/tools/dream/output.py
+++ b/src/tools/dream/output.py
@@ -270,6 +270,33 @@ def format_dream_output(
         "没有沉淀就不写，不强迫产出。\n\n"
     )
 
+    try:
+        plans_active = [
+            b for b in all_buckets
+            if b["metadata"].get("type") == "plan"
+            and not is_letter_bucket(b)
+            and b["metadata"].get("status", "active") == "active"
+            and not parse_bool(
+                (b.get("metadata") or {}).get("protected"), default=False
+            )
+        ]
+        plans_active.sort(
+            key=lambda b: b["metadata"].get("created", ""), reverse=True
+        )
+    except Exception as e:
+        rt.logger.warning(f"Dream active plans collection failed: {e}")
+        plans_active = []
+
+    plan_fallback = (
+        "\n\n=== 你的 active plans ===\n"
+        f"（active plan {len(plans_active)} 条，因篇幅未列出。）"
+        if plans_active
+        else ""
+    )
+    # 在近期记忆与核心准则填充预算时，预留一行给不可衰退的开放计划。
+    # 即使完整 plan block 都放不下，也不能让 active plan 无声消失。
+    reserved_suffix = plan_fallback
+
     final_text = header
     rendered_candidate_ids: list[str] = []
     rendered_candidate_id_set: set[str] = set()
@@ -283,7 +310,7 @@ def format_dream_output(
     def append_fragment(fragment: str) -> bool:
         nonlocal final_text
         candidate = final_text + fragment
-        if count_tokens_approx(candidate) > dream_budget:
+        if count_tokens_approx(candidate + reserved_suffix) > dream_budget:
             return False
         final_text = candidate
         return True
@@ -326,7 +353,7 @@ def format_dream_output(
             )
             candidate_lines = [*core_lines, block]
             candidate = core_prefix + "\n---\n".join(candidate_lines)
-            if count_tokens_approx(final_text + candidate) <= dream_budget:
+            if count_tokens_approx(final_text + candidate + reserved_suffix) <= dream_budget:
                 core_lines.append(block)
             else:
                 core_omitted += 1
@@ -334,22 +361,13 @@ def format_dream_output(
             section = core_prefix + "\n---\n".join(core_lines)
             if core_omitted:
                 notice = f"\n\n（另有 {core_omitted} 条核心记忆因 dream 总预算未展开。）"
-                if count_tokens_approx(final_text + section + notice) <= dream_budget:
+                if count_tokens_approx(final_text + section + notice + reserved_suffix) <= dream_budget:
                     section += notice
             append_fragment(section)
 
     # --- ③ active plan 段 ---
     try:
-        plans_active = [
-            b for b in all_buckets
-            if b["metadata"].get("type") == "plan"
-            and not is_letter_bucket(b)
-            and b["metadata"].get("status", "active") == "active"
-            and not parse_bool(
-                (b.get("metadata") or {}).get("protected"), default=False
-            )
-        ]
-        plans_active.sort(key=lambda b: b["metadata"].get("created", ""), reverse=True)
+        reserved_suffix = ""
         if plans_active:
             plan_prefix = (
                 "\n\n=== 你的 active plans ===\n"
@@ -366,18 +384,32 @@ def format_dream_output(
                     display_prefix=f"[{p['id']}] {pcreated} ",
                     footprint=_footprint(p),
                 )
+                suggestion = pmeta.get("resolution_suggested")
+                if isinstance(suggestion, dict):
+                    reason = str(suggestion.get("reason") or "未提供理由").strip()
+                    block += f"\n（系统认为可能已完成：{reason}）"
                 candidate = plan_prefix + "\n".join([*plan_lines, block])
                 if count_tokens_approx(final_text + candidate) <= dream_budget:
                     plan_lines.append(block)
                 else:
                     plan_omitted += 1
-            if plan_lines:
-                section = plan_prefix + "\n".join(plan_lines)
-                if plan_omitted:
-                    notice = f"\n\n（另有 {plan_omitted} 条 active plan 因 dream 总预算未展开。）"
-                    if count_tokens_approx(final_text + section + notice) <= dream_budget:
-                        section += notice
-                append_fragment(section)
+            if plan_omitted:
+                while plan_lines:
+                    notice = (
+                        f"\n\n（另有 {plan_omitted} 条 active plan "
+                        "因 dream 总预算未展开。）"
+                    )
+                    section = plan_prefix + "\n".join(plan_lines) + notice
+                    if count_tokens_approx(final_text + section) <= dream_budget:
+                        break
+                    plan_lines.pop()
+                    plan_omitted += 1
+                if plan_lines:
+                    append_fragment(section)
+                else:
+                    append_fragment(plan_fallback)
+            elif plan_lines:
+                append_fragment(plan_prefix + "\n".join(plan_lines))
     except Exception as e:
         rt.logger.warning(f"Dream active plans block failed: {e}")
 

--- a/src/tools/dream/output.py
+++ b/src/tools/dream/output.py
@@ -386,8 +386,12 @@ def format_dream_output(
                 )
                 suggestion = pmeta.get("resolution_suggested")
                 if isinstance(suggestion, dict):
-                    reason = str(suggestion.get("reason") or "未提供理由").strip()
-                    block += f"\n（系统认为可能已完成：{reason}）"
+                    reason = " ".join(
+                        str(suggestion.get("reason") or "未提供理由").split()
+                    )
+                    suggested_date = str(suggestion.get("ts") or "").strip()[:10]
+                    date_suffix = f"，{suggested_date}" if suggested_date else ""
+                    block += f"\n（系统认为可能已完成{date_suffix}：{reason}）"
                 candidate = plan_prefix + "\n".join([*plan_lines, block])
                 if count_tokens_approx(final_text + candidate) <= dream_budget:
                     plan_lines.append(block)

--- a/src/tools/grow/core.py
+++ b/src/tools/grow/core.py
@@ -15,7 +15,7 @@ tools/grow/core.py — grow 长内容主路径（digest + merge）
   source_tool 一律为 ``grow``；合并到的老桶不改 source_tool
 - 单条失败不影响其他；按字节上限校验单条尺寸
 - embedding 失败时桶正常创建，返回追加向量化降级警告
-- 末尾 fire-and-forget 触发 plan 自动闭环（用整段原文做匹配）
+- 末尾 fire-and-forget 触发 plan 完成建议（用整段原文做匹配）
 
 不做什么（边界）：
 - 不写 feel：grow 是事件归档，不是反思

--- a/src/tools/grow/shortpath.py
+++ b/src/tools/grow/shortpath.py
@@ -10,7 +10,7 @@ merge_or_create，省一次 LLM 拆分调用。
 - 调 analyze 拿 domain/valence/arousal/tags/suggested_name
 - 用 raw_merge=True 与 hold 对齐：保留原文不压缩（修了 2.0 之前
   短日记被 LLM 偷偷压缩的 bug）
-- 写完 fire-and-forget：plan 自动闭环 + 新桶疑似重复扫描
+- 写完 fire-and-forget：plan 完成建议 + 新桶疑似重复扫描
 
 不做什么（边界）：
 - 不拆分：短到这种程度本就该是单条

--- a/src/tools/hold/__init__.py
+++ b/src/tools/hold/__init__.py
@@ -10,7 +10,7 @@ core（普通存入 + 自动合并）。
 关键行为：
 - null-safe 兜底；先做 content / 字节上限校验，再分支
 - feel=True / pinned=True 是互斥分支，否则走 core
-- core 写完后 fire-and-forget 触发 plan 自动闭环 + 疑似重复扫描
+- core 写完后 fire-and-forget 触发 plan 完成建议 + 疑似重复扫描
 
 不做什么（边界）：
 - 不在这里做 LLM 打标，分支模块负责

--- a/src/tools/hold/core.py
+++ b/src/tools/hold/core.py
@@ -14,7 +14,7 @@ tools/hold/core.py — hold 普通存入分支（含自动合并）
 - 调 _common.merge_or_create 走合并/新建
 - iter 2.0：source_tool 写 ``hold``；合并到老桶时只更新 ``last_merged_by``
 - embedding 失败时桶正常创建，返回追加向量化降级警告
-- 写完 fire-and-forget：plan 自动闭环判断 + 新桶疑似重复扫描
+- 写完 fire-and-forget：plan 完成建议判断 + 新桶疑似重复扫描
 
 不做什么（边界）：
 - 不做 pinned 配额检查（那是 pinned 分支的事）

--- a/src/tools/plan/core.py
+++ b/src/tools/plan/core.py
@@ -294,7 +294,7 @@ async def plan_create(
         event_actor="llm",
     )
     from .._common import append_plan_change_log
-    initial_log = append_plan_change_log([], "created", to=status)
+    initial_log = append_plan_change_log([], "created", to=status, by="plan")
     update_kwargs = {"status": status, "change_log": initial_log}
     if related_bucket.strip():
         update_kwargs["related_bucket"] = related_bucket.strip()

--- a/src/tools/trace/core.py
+++ b/src/tools/trace/core.py
@@ -636,6 +636,11 @@ async def trace_core(
                 history = append_plan_change_log(history, "edit", by="trace")
             updates["change_log"] = history
 
+        if is_plan and ("status" in updates or content_change_requested):
+            # 显式状态/正文变更会让旧完成建议失效；None 由 BucketManager
+            # 解释为删除 frontmatter 字段。失败的局部替换不会进入提交路径。
+            updates["resolution_suggested"] = None
+
         if patch_args_supplied:
             patch_result = await rt.bucket_mgr.update_content_fragment(
                 bucket_id,
@@ -699,7 +704,10 @@ async def trace_core(
 
     _display_updates = {
         k: v for k, v in updates.items()
-        if k not in ("content", "meaning_append", "meaning", "media_append", "media")
+        if k not in (
+            "content", "meaning_append", "meaning", "media_append", "media",
+            "resolution_suggested",
+        )
     }
     changed = ", ".join(f"{k}={v}" for k, v in _display_updates.items())
     if patch_args_supplied:

--- a/src/tools/trace/core.py
+++ b/src/tools/trace/core.py
@@ -622,13 +622,18 @@ async def trace_core(
             from .._common import append_plan_change_log
             old_meta = bucket.get("metadata", {})
             history = list(old_meta.get("change_log") or [])
-            if "status" in updates and updates["status"] != old_meta.get("status"):
+            old_status = old_meta.get("status") or "active"
+            if "status" in updates and updates["status"] != old_status:
                 history = append_plan_change_log(
                     history, "status",
-                    **{"from": old_meta.get("status"), "to": updates["status"]},
+                    **{
+                        "from": old_status,
+                        "to": updates["status"],
+                        "by": "trace",
+                    },
                 )
             if content_change_requested:
-                history = append_plan_change_log(history, "edit")
+                history = append_plan_change_log(history, "edit", by="trace")
             updates["change_log"] = history
 
         if patch_args_supplied:

--- a/src/web/plans.py
+++ b/src/web/plans.py
@@ -57,8 +57,8 @@ def register(mcp) -> None:
                     "name": meta.get("name") or "",
                     "content": b.get("content", ""),
                     "status": st,
-                    "created_at": meta.get("created_at"),
-                    "updated_at": meta.get("updated_at"),
+                    "created_at": meta.get("created"),
+                    "updated_at": meta.get("last_active"),
                     "related_bucket": meta.get("related_bucket"),
                     "change_log": meta.get("change_log") or [],
                     "tags": meta.get("tags") or [],
@@ -149,7 +149,11 @@ def register(mcp) -> None:
                     updates["status"] = new_status
                     history = append_plan_change_log(
                         history, "status",
-                        **{"from": old_status, "to": new_status},
+                        **{
+                            "from": old_status,
+                            "to": new_status,
+                            "by": "dashboard",
+                        },
                     )
             elif action == "edit":
                 new_content = body.get("content", "")
@@ -160,7 +164,7 @@ def register(mcp) -> None:
                 if size_err:
                     return JSONResponse({"error": size_err}, status_code=400)
                 updates["content"] = new_content.strip()
-                history = append_plan_change_log(history, "edit")
+                history = append_plan_change_log(history, "edit", by="dashboard")
             else:
                 return JSONResponse({"error": f"unknown action: {action}"}, status_code=400)
 

--- a/src/web/plans.py
+++ b/src/web/plans.py
@@ -171,6 +171,9 @@ def register(mcp) -> None:
             # status 没变 且 不是 edit，成 noop。返回 200 + ok=true，不报错
             if not updates:
                 return JSONResponse({"ok": True, "noop": True})
+            # status 或正文经显式动作改变后，旧完成建议所依据的 plan 已失效。
+            # None 由 BucketManager 解释为删除 frontmatter 字段。
+            updates["resolution_suggested"] = None
             updates["change_log"] = history
             ok = await sh.bucket_mgr.update(bucket_id, **updates)
             if not ok:
@@ -189,7 +192,10 @@ def register(mcp) -> None:
             return JSONResponse({
                 "ok": True,
                 "id": bucket_id,
-                "updates": {k: v for k, v in updates.items() if k != "change_log"},
+                "updates": {
+                    k: v for k, v in updates.items()
+                    if k not in ("change_log", "resolution_suggested")
+                },
                 "cascaded_resolved": cascaded,
             })
         except ValueError as e:

--- a/tests/test_code_health_regressions.py
+++ b/tests/test_code_health_regressions.py
@@ -166,6 +166,75 @@ async def test_plan_edit_rejects_oversized_content_without_updating(monkeypatch)
 
 
 @pytest.mark.asyncio
+async def test_plan_api_uses_canonical_created_and_last_active(monkeypatch):
+    class BucketManager:
+        async def list_all(self, include_archive=False):
+            assert include_archive is False
+            return [{
+                "id": "plan-1",
+                "content": "计划正文",
+                "metadata": {
+                    "type": "plan",
+                    "status": "active",
+                    "created": "2026-08-12T10:00:00",
+                    "last_active": "2026-08-12T11:00:00",
+                },
+            }]
+
+    monkeypatch.setattr(plans_web.sh, "_require_auth", lambda _request: None)
+    monkeypatch.setattr(plans_web.sh, "bucket_mgr", BucketManager(), raising=False)
+    mcp = FakeMCP()
+    plans_web.register(mcp)
+
+    response = await mcp.routes[("GET", "/api/plans")](JsonRequest())
+    plan = _json(response)["active"][0]
+
+    assert plan["created_at"] == "2026-08-12T10:00:00"
+    assert plan["updated_at"] == "2026-08-12T11:00:00"
+
+
+@pytest.mark.asyncio
+async def test_plan_dashboard_status_change_records_actor(monkeypatch):
+    class BucketManager:
+        def __init__(self):
+            self.updates = []
+
+        async def get(self, bucket_id):
+            return {
+                "id": bucket_id,
+                "content": "计划正文",
+                "metadata": {
+                    "type": "plan",
+                    "status": "active",
+                    "change_log": [],
+                },
+            }
+
+        async def update(self, bucket_id, **updates):
+            self.updates.append((bucket_id, updates))
+            return True
+
+    manager = BucketManager()
+    monkeypatch.setattr(plans_web.sh, "_require_auth", lambda _request: None)
+    monkeypatch.setattr(plans_web.sh, "bucket_mgr", manager, raising=False)
+    mcp = FakeMCP()
+    plans_web.register(mcp)
+
+    response = await mcp.routes[("POST", "/api/plans/{bucket_id}/action")](
+        JsonRequest({"action": "resolve"}, path_params={"bucket_id": "plan-1"})
+    )
+
+    assert response.status_code == 200
+    _, updates = manager.updates[0]
+    entry = updates["change_log"][-1]
+    assert entry["action"] == "status"
+    assert entry["from"] == "active"
+    assert entry["to"] == "resolved"
+    assert entry["by"] == "dashboard"
+    assert entry["ts"]
+
+
+@pytest.mark.asyncio
 async def test_ollama_pull_bounds_connection_waits_but_allows_long_stream(monkeypatch):
     captured = {}
 

--- a/tests/test_code_health_regressions.py
+++ b/tests/test_code_health_regressions.py
@@ -207,6 +207,10 @@ async def test_plan_dashboard_status_change_records_actor(monkeypatch):
                     "type": "plan",
                     "status": "active",
                     "change_log": [],
+                    "resolution_suggested": {
+                        "reason": "计划可能已完成",
+                        "ts": "2026-08-12T12:00:00",
+                    },
                 },
             }
 
@@ -232,6 +236,53 @@ async def test_plan_dashboard_status_change_records_actor(monkeypatch):
     assert entry["to"] == "resolved"
     assert entry["by"] == "dashboard"
     assert entry["ts"]
+    assert updates["resolution_suggested"] is None
+
+
+@pytest.mark.asyncio
+async def test_plan_dashboard_edit_clears_resolution_suggestion(monkeypatch):
+    class BucketManager:
+        def __init__(self):
+            self.updates = []
+
+        async def get(self, bucket_id):
+            return {
+                "id": bucket_id,
+                "content": "旧计划正文",
+                "metadata": {
+                    "type": "plan",
+                    "status": "active",
+                    "change_log": [],
+                    "resolution_suggested": {
+                        "reason": "旧正文可能已完成",
+                        "ts": "2026-08-12T12:00:00",
+                    },
+                },
+            }
+
+        async def update(self, bucket_id, **updates):
+            self.updates.append((bucket_id, updates))
+            return True
+
+    manager = BucketManager()
+    monkeypatch.setattr(plans_web.sh, "_require_auth", lambda _request: None)
+    monkeypatch.setattr(plans_web.sh, "bucket_mgr", manager, raising=False)
+    mcp = FakeMCP()
+    plans_web.register(mcp)
+
+    response = await mcp.routes[("POST", "/api/plans/{bucket_id}/action")](
+        JsonRequest(
+            {"action": "edit", "content": "新计划正文"},
+            path_params={"bucket_id": "plan-1"},
+        )
+    )
+
+    assert response.status_code == 200
+    _, updates = manager.updates[0]
+    assert updates["content"] == "新计划正文"
+    assert updates["resolution_suggested"] is None
+    assert updates["change_log"][-1]["action"] == "edit"
+    assert updates["change_log"][-1]["by"] == "dashboard"
 
 
 @pytest.mark.asyncio

--- a/tests/test_dream_prompt_boundary.py
+++ b/tests/test_dream_prompt_boundary.py
@@ -181,7 +181,7 @@ def test_active_plan_resolution_suggestion_is_visible():
     )
 
     assert "仍由人决定是否关闭的计划" in result
-    assert "（系统认为可能已完成：相关事件看起来已经完成）" in result
+    assert "（系统认为可能已完成，2026-08-12：相关事件看起来已经完成）" in result
 
 
 def test_collapsed_feel_is_shown_with_ellipsis_truncation_and_stays_bounded(monkeypatch):

--- a/tests/test_dream_prompt_boundary.py
+++ b/tests/test_dream_prompt_boundary.py
@@ -158,6 +158,32 @@ def test_protected_plan_and_feel_never_enter_dream_output():
     assert "=== 你的 feel 历史" not in result
 
 
+def test_active_plan_resolution_suggestion_is_visible():
+    plan = _bucket(
+        "plan-suggested",
+        "仍由人决定是否关闭的计划",
+        "plan",
+        status="active",
+        resolution_suggested={
+            "reason": "相关事件看起来已经完成",
+            "confidence": 0.91,
+            "suggested_by": "plan_resolution_judge",
+            "ts": "2026-08-12T12:00:00",
+        },
+    )
+
+    result = dream_output.format_dream_output(
+        recent=[],
+        all_buckets=[plan],
+        window_hours=48,
+        connection_hint="",
+        crystal_hint="",
+    )
+
+    assert "仍由人决定是否关闭的计划" in result
+    assert "（系统认为可能已完成：相关事件看起来已经完成）" in result
+
+
 def test_collapsed_feel_is_shown_with_ellipsis_truncation_and_stays_bounded(monkeypatch):
     feel_budget = 1200
     monkeypatch.setattr(
@@ -264,3 +290,4 @@ def test_dream_global_budget_omits_whole_blocks_without_truncating_bodies(
     assert dream_output.count_tokens_approx(result) <= budget
     _assert_no_markers(result)
     assert "dream 总预算未展开" in result
+    assert "（active plan 4 条，因篇幅未列出。）" in result

--- a/tests/test_memory_boundary_regressions.py
+++ b/tests/test_memory_boundary_regressions.py
@@ -22,7 +22,7 @@ class _Logger:
 
 
 @pytest.mark.asyncio
-async def test_plan_resolution_keyword_fallback_reaches_related_plan_beyond_cap(
+async def test_plan_resolution_keyword_match_records_suggestion_without_closing(
     monkeypatch,
 ):
     plans = [
@@ -75,14 +75,55 @@ async def test_plan_resolution_keyword_fallback_reaches_related_plan_beyond_cap(
         "Zeabur 模板已经发布完成", source_bucket_id="event-1"
     )
 
-    assert manager.updated == [(
-        "plan-related",
-        {
-            "status": "resolved",
-            "resolution_reason": "模板已经发布",
-            "resolved_by": "event-1",
-        },
-    )]
+    assert len(manager.updated) == 1
+    bucket_id, changes = manager.updated[0]
+    assert bucket_id == "plan-related"
+    assert set(changes) == {"resolution_suggested"}
+    suggestion = changes["resolution_suggested"]
+    assert suggestion["reason"] == "模板已经发布"
+    assert suggestion["confidence"] == 0.95
+    assert suggestion["suggested_by"] == "plan_resolution_judge"
+    assert suggestion["source_bucket_id"] == "event-1"
+    assert suggestion["ts"]
+
+
+@pytest.mark.asyncio
+async def test_unmatched_active_plan_is_not_judged_or_closed(monkeypatch):
+    plan = {
+        "id": "plan-unmatched",
+        "content": "完全无关的开放计划",
+        "metadata": {"type": "plan", "status": "active"},
+    }
+
+    class Manager:
+        def __init__(self):
+            self.updated = []
+
+        async def list_all(self, include_archive=False):
+            assert include_archive is False
+            return [plan]
+
+        async def search(self, _query, limit=None, vector_scores=None):
+            assert limit >= 1
+            assert vector_scores == {}
+            return []
+
+        async def update(self, bucket_id, **changes):
+            self.updated.append((bucket_id, changes))
+
+    class Judge:
+        async def judge_plan_resolution(self, _plan_text, _new_event_text):
+            pytest.fail("未命中检索的 plan 不应交给 LLM 判断")
+
+    manager = Manager()
+    monkeypatch.setattr(rt, "bucket_mgr", manager, raising=False)
+    monkeypatch.setattr(rt, "embedding_engine", None, raising=False)
+    monkeypatch.setattr(rt, "dehydrator", Judge(), raising=False)
+    monkeypatch.setattr(rt, "logger", _Logger(), raising=False)
+
+    await common.check_plan_resolution("刚完成另一件不相关的事")
+
+    assert manager.updated == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_trace_content_patch_regression.py
+++ b/tests/test_trace_content_patch_regression.py
@@ -367,3 +367,57 @@ async def test_trace_patch_records_plan_edit_change_log(trace_runtime):
     assert bucket is not None
     assert bucket["content"] == "计划新正文"
     assert bucket["metadata"]["change_log"][-1]["action"] == "edit"
+
+
+@pytest.mark.asyncio
+async def test_trace_plan_status_change_records_actor(trace_runtime):
+    manager = trace_runtime
+    bucket_id = await manager.create(
+        content="待完成计划",
+        bucket_type="plan",
+        weight=0.7,
+    )
+    await manager.update(bucket_id, status="active", change_log=[])
+
+    result = await trace_core(bucket_id, status="resolved")
+    bucket = await manager.get(bucket_id)
+
+    assert "status=resolved" in result
+    assert bucket is not None
+    entry = bucket["metadata"]["change_log"][-1]
+    assert entry["action"] == "status"
+    assert entry["from"] == "active"
+    assert entry["to"] == "resolved"
+    assert entry["by"] == "trace"
+    assert entry["ts"]
+
+
+@pytest.mark.asyncio
+async def test_trace_plan_patch_and_status_change_records_actor(trace_runtime):
+    manager = trace_runtime
+    bucket_id = await manager.create(
+        content="旧计划正文",
+        bucket_type="plan",
+        weight=0.7,
+    )
+    await manager.update(bucket_id, status="active", change_log=[])
+
+    result = await trace_core(
+        bucket_id,
+        old_str="旧计划",
+        new_str="新计划",
+        status="resolved",
+    )
+    bucket = await manager.get(bucket_id)
+
+    assert "content=已局部替换" in result
+    assert bucket is not None
+    assert bucket["content"] == "新计划正文"
+    status_entry, edit_entry = bucket["metadata"]["change_log"][-2:]
+    assert status_entry["action"] == "status"
+    assert status_entry["from"] == "active"
+    assert status_entry["to"] == "resolved"
+    assert status_entry["by"] == "llm"
+    assert status_entry["ts"]
+    assert edit_entry["action"] == "edit"
+    assert edit_entry["by"] == "llm"

--- a/tests/test_trace_content_patch_regression.py
+++ b/tests/test_trace_content_patch_regression.py
@@ -355,6 +355,16 @@ async def test_trace_patch_records_plan_edit_change_log(trace_runtime):
         bucket_type="plan",
         weight=0.7,
     )
+    await manager.update(
+        bucket_id,
+        resolution_suggested={
+            "reason": "旧正文可能已完成",
+            "ts": "2026-08-12T12:00:00",
+        },
+    )
+    before = await manager.get(bucket_id)
+    assert before is not None
+    assert "resolution_suggested" in before["metadata"]
 
     result = await trace_core(
         bucket_id,
@@ -366,6 +376,7 @@ async def test_trace_patch_records_plan_edit_change_log(trace_runtime):
     assert "content=已局部替换" in result
     assert bucket is not None
     assert bucket["content"] == "计划新正文"
+    assert "resolution_suggested" not in bucket["metadata"]
     assert bucket["metadata"]["change_log"][-1]["action"] == "edit"
 
 
@@ -377,13 +388,25 @@ async def test_trace_plan_status_change_records_actor(trace_runtime):
         bucket_type="plan",
         weight=0.7,
     )
-    await manager.update(bucket_id, status="active", change_log=[])
+    await manager.update(
+        bucket_id,
+        status="active",
+        change_log=[],
+        resolution_suggested={
+            "reason": "计划可能已完成",
+            "ts": "2026-08-12T12:00:00",
+        },
+    )
+    before = await manager.get(bucket_id)
+    assert before is not None
+    assert "resolution_suggested" in before["metadata"]
 
     result = await trace_core(bucket_id, status="resolved")
     bucket = await manager.get(bucket_id)
 
     assert "status=resolved" in result
     assert bucket is not None
+    assert "resolution_suggested" not in bucket["metadata"]
     entry = bucket["metadata"]["change_log"][-1]
     assert entry["action"] == "status"
     assert entry["from"] == "active"


### PR DESCRIPTION
## What changed

- restrict plan-resolution candidates to keyword/vector retrieval hits
- record high-confidence LLM results as `resolution_suggested` metadata instead of writing `status=resolved`
- ensure explicit plan status/edit paths append actor-aware change-log entries
- surface resolution suggestions in Dream's active-plan section
- reserve Dream budget for active plans and emit a fallback count when details do not fit
- correct `/api/plans` timestamps to canonical `created` / `last_active` metadata
- add regression coverage for resolution authority, Dream visibility/budget behavior, change logs, and trace patch behavior

## Why

The background plan-resolution judge was both over-broad and over-authorized: it evaluated every active plan as a fallback and could directly close a plan without an explicit user/tool action or a complete audit trail. A heuristic that is not trusted to trigger related-event closure should not have authority to set `status=resolved`; it now produces a reviewable suggestion only.

## Impact

Plans remain active until an explicit `plan(status="resolved")` or `trace(status="resolved")` action confirms completion. Suggestions remain visible to users through Dream.

## Validation

- Ruff checks passed
- `git diff --check` passed
- targeted pytest selection reached 100% (38 tests); the process did not exit cleanly because background threads remained alive and was stopped by the outer timeout
