### PR TITLE
fix(dream): stop returning pinned memory content

### DIFF
--- a/src/tools/dream/__init__.py
+++ b/src/tools/dream/__init__.py
@@ -7,7 +7,7 @@ dream 是「我做一次梦——读最近 N 小时内有变动的所有桶，�
 一遍」。这里把整个流程拆成三步：
 1. candidates.py：筛选窗口内的桶 + 软上限
 2. hints.py：连接提示 + 结晶提示 + 待沉淀 I 候选与它们撞上的材料
-3. output.py：拼最终文本（近期活跃/核心准则/active plan/feel 历史/
+3. output.py：拼最终文本（近期活跃/active plan/feel 历史/
    连接提示/结晶提示/I 候选段）
 
 dispatch() 把这几步串起来，并给最终输出中实际出现的候选各记一次
@@ -22,7 +22,7 @@ from typing import Optional
 
 from ..i import record_dream_pass
 from .. import _runtime as rt
-from .candidates import collect_candidates, collect_core_context
+from .candidates import collect_candidates
 from .hints import build_connection_hint, build_crystal_hint, collect_self_candidates
 from .output import format_dream_output
 
@@ -40,14 +40,13 @@ async def dispatch(
 
     window_hours = max(1, min(int(window_hours or 48), 24 * 14))
     recent = collect_candidates(all_buckets, window_hours)
-    core_context = collect_core_context(all_buckets)
     try:
         self_review = await collect_self_candidates(all_buckets, window_hours)
     except Exception as exc:
         rt.logger.warning(f"Dream self candidate collection failed: {exc}")
         self_review = None
     has_self_candidates = bool(getattr(self_review, "candidates", None))
-    if not recent and not core_context and not has_self_candidates:
+    if not recent and not has_self_candidates:
         return f"过去 {window_hours} 小时内没有需要消化的新记忆。"
 
     connection_hint = await build_connection_hint(recent)
@@ -59,7 +58,6 @@ async def dispatch(
         window_hours=window_hours,
         connection_hint=connection_hint,
         crystal_hint=crystal_hint,
-        core_context=core_context,
         self_review=self_review,
     )
 

--- a/src/tools/dream/candidates.py
+++ b/src/tools/dream/candidates.py
@@ -68,6 +68,35 @@ def is_within_window(meta: dict, cutoff: datetime) -> bool:
     return False
 
 
+def collect_core_context(all_buckets: list) -> list:
+    """Compatibility selector for callers that still inspect dream core candidates.
+
+    Dream dispatch intentionally no longer consumes or renders this list.  Keep
+    the selector available for policy/regression callers without reintroducing
+    pinned/permanent content into dream output.
+    """
+    core = [
+        b for b in all_buckets
+        if (
+            b["metadata"].get("pinned", False)
+            or b["metadata"].get("type") == "permanent"
+        )
+        and not parse_bool(b["metadata"].get("protected"), default=False)
+        and _can_dream(b)
+        and not is_letter_bucket(b)
+        and b["metadata"].get("type") not in ("letter", "self", "i")
+    ]
+    core.sort(
+        key=lambda b: (
+            int(b["metadata"].get("importance") or 0),
+            _metadata_timestamp(b["metadata"]),
+            b.get("id", ""),
+        ),
+        reverse=True,
+    )
+    return core[:20]
+
+
 def collect_candidates(all_buckets: list, window_hours: int) -> list:
     candidates = [
         b for b in all_buckets

--- a/src/tools/dream/candidates.py
+++ b/src/tools/dream/candidates.py
@@ -68,29 +68,6 @@ def is_within_window(meta: dict, cutoff: datetime) -> bool:
     return False
 
 
-def collect_core_context(all_buckets: list) -> list:
-    core = [
-        b for b in all_buckets
-        if (
-            b["metadata"].get("pinned", False)
-            or b["metadata"].get("type") == "permanent"
-        )
-        and not parse_bool(b["metadata"].get("protected"), default=False)
-        and _can_dream(b)
-        and not is_letter_bucket(b)
-        and b["metadata"].get("type") not in ("letter", "self", "i")
-    ]
-    core.sort(
-        key=lambda b: (
-            int(b["metadata"].get("importance") or 0),
-            _metadata_timestamp(b["metadata"]),
-            b.get("id", ""),
-        ),
-        reverse=True,
-    )
-    return core[:20]
-
-
 def collect_candidates(all_buckets: list, window_hours: int) -> list:
     candidates = [
         b for b in all_buckets

--- a/src/tools/dream/hints.py
+++ b/src/tools/dream/hints.py
@@ -201,6 +201,7 @@ async def collect_self_candidates(all_buckets: list, window_hours: int) -> SelfR
             if b["id"] not in pending_ids
             and not is_letter_bucket(b)
             and (b.get("metadata") or {}).get("type") == "i"
+            and not (b.get("metadata") or {}).get("pinned", False)
             and not parse_bool(
                 (b.get("metadata") or {}).get("protected"), default=False
             )
@@ -210,6 +211,7 @@ async def collect_self_candidates(all_buckets: list, window_hours: int) -> SelfR
             if b["id"] not in pending_ids
             and not is_letter_bucket(b)
             and (b.get("metadata") or {}).get("type") not in ("i", "letter")
+            and not (b.get("metadata") or {}).get("pinned", False)
             and not parse_bool(
                 (b.get("metadata") or {}).get("protected"), default=False
             )

--- a/src/tools/dream/output.py
+++ b/src/tools/dream/output.py
@@ -6,15 +6,14 @@ tools/dream/output.py — dream 最终输出格式化
 把 candidates / hints / active plan / 全量 feel 历史拼成一段长文本
 返回给模型自我反省。
 
-最终七个板块，按下列顺序输出：
+最终六个板块，按下列顺序输出：
 ① 近期活跃记忆正文（48 小时窗口，排除 pinned/resolved/protected/permanent/
    feel/plan/letter/digested/dont_surface/anchor）
-② 核心准则参考（pinned/permanent，排除 protected）
-③ 你的 active plans
-④ 你的 feel 历史（按 token 预算折叠老 feel）
-⑤ connection hint（最相似的一对近期记忆）
-⑥ crystal hint（低频触发：feel 聚成一簇 5 条才提示一次）
-⑦「我觉得」I 候选段（选取规则并入①的同一套 48 小时/排除 pinned/排除
+② 你的 active plans（排除 pinned）
+③ 你的 feel 历史（按 token 预算折叠老 feel，排除 pinned）
+④ connection hint（最相似的一对近期记忆）
+⑤ crystal hint（低频触发：feel 聚成一簇 5 条才提示一次）
+⑥「我觉得」I 候选段（选取规则并入①的同一套 48 小时/排除 pinned/排除
    resolved 规则；protected 排除单独保留）
 
 关键行为：
@@ -190,7 +189,6 @@ def format_dream_output(
     window_hours: int,
     connection_hint: str,
     crystal_hint: str,
-    core_context: list | None = None,
     self_review: object | None = None,
 ) -> str:
     runtime_config = rt.config if isinstance(rt.config, dict) else {}
@@ -303,47 +301,13 @@ def format_dream_output(
             f"\n\n（另有 {recent_omitted} 条近期记忆因 dream 总预算未展开。）"
         )
 
-    # --- ② 核心准则参考 ---
-    core_context = core_context or []
-    if core_context:
-        core_prefix = (
-            "\n\n=== 核心准则参考 ===\n"
-            "这些是 pinned/permanent 桶，只作为梦里的边界与背景，不当作普通待消化事项。\n\n"
-        )
-        core_lines: list[str] = []
-        core_omitted = 0
-        for b in core_context:
-            meta = b["metadata"]
-            domains = ",".join(meta.get("domain", []))
-            block = _bucket_data_block(
-                b,
-                display_prefix=(
-                    f"📌 [{b['id']}] {meta.get('name', b['id'])} "
-                    f"主题:{domains or '未分类'} 重要:{meta.get('importance', '?')}"
-                    f"{_miss_lines(meta)}\n"
-                ),
-                footprint=_footprint(b),
-            )
-            candidate_lines = [*core_lines, block]
-            candidate = core_prefix + "\n---\n".join(candidate_lines)
-            if count_tokens_approx(final_text + candidate) <= dream_budget:
-                core_lines.append(block)
-            else:
-                core_omitted += 1
-        if core_lines:
-            section = core_prefix + "\n---\n".join(core_lines)
-            if core_omitted:
-                notice = f"\n\n（另有 {core_omitted} 条核心记忆因 dream 总预算未展开。）"
-                if count_tokens_approx(final_text + section + notice) <= dream_budget:
-                    section += notice
-            append_fragment(section)
-
-    # --- ③ active plan 段 ---
+    # --- ② active plan 段 ---
     try:
         plans_active = [
             b for b in all_buckets
             if b["metadata"].get("type") == "plan"
             and not is_letter_bucket(b)
+            and not (b.get("metadata") or {}).get("pinned", False)
             and b["metadata"].get("status", "active") == "active"
             and not parse_bool(
                 (b.get("metadata") or {}).get("protected"), default=False
@@ -381,12 +345,13 @@ def format_dream_output(
     except Exception as e:
         rt.logger.warning(f"Dream active plans block failed: {e}")
 
-    # --- ④ 全量 feel 段（按 token 预算折叠老 feel）---
+    # --- ③ 全量 feel 段（按 token 预算折叠老 feel）---
     try:
         feels_all = [
             b for b in all_buckets
             if b["metadata"].get("type") == "feel"
             and not is_letter_bucket(b)
+            and not (b.get("metadata") or {}).get("pinned", False)
             and not parse_bool(
                 (b.get("metadata") or {}).get("protected"), default=False
             )
@@ -459,12 +424,12 @@ def format_dream_output(
     except Exception as e:
         rt.logger.warning(f"Dream feel history failed: {e}")
 
-    # --- ⑤/⑥ connection hint / crystal hint ---
+    # --- ④/⑤ connection hint / crystal hint ---
     for hint in (connection_hint, crystal_hint):
         if hint:
             append_fragment("\n" + hint)
 
-    # --- ⑦ I 候选段 ---
+    # --- ⑥ I 候选段 ---
     # 放在最后：待沉淀的「我觉得」需要挨着上面已经展示过的近期记忆、
     # plan、feel 和两条提示一起看，碰撞才有完整上下文。
     if self_review is not None:

--- a/tests/test_dream_prompt_boundary.py
+++ b/tests/test_dream_prompt_boundary.py
@@ -83,7 +83,7 @@ def test_malicious_memory_is_returned_verbatim_without_any_safety_markers():
     assert "content_role:stored_memory_data" not in result
 
 
-def test_every_persisted_dream_surface_is_shown_verbatim_without_changing_legal_bodies(
+def test_dream_omits_pinned_bodies_but_keeps_other_surfaces_verbatim(
     monkeypatch,
 ):
     monkeypatch.setattr(dream_output.rt, "config", {"surfacing": {"feel_max_tokens": 10_000}})
@@ -103,17 +103,16 @@ def test_every_persisted_dream_surface_is_shown_verbatim_without_changing_legal_
         window_hours=24,
         connection_hint="\n💭 normal connection [[hint]]\n",
         crystal_hint="\n🔮 normal crystal hint\n",
-        core_context=[core],
     )
 
-    # 四类正文（近期/核心准则/plan/feel）都只做双链清理，逐字出现，
-    # 不附加任何边界/哈希/协议说明标记。
-    for body in (recent_body, core_body, plan_body, feel_body):
+    # dream 不再返回 pinned 正文；其余正文仍只做双链清理并逐字出现。
+    for body in (recent_body, plan_body, feel_body):
         assert dream_output.strip_wikilinks(body) in result
+    assert dream_output.strip_wikilinks(core_body) not in result
     _assert_no_markers(result)
 
     assert "=== Dreaming · 过去 24 小时全量记忆（1 个桶）===" in result
-    assert "=== 核心准则参考 ===" in result
+    assert "=== 核心准则参考 ===" not in result
     assert "=== 你的 active plans ===" in result
     assert "=== 你的 feel 历史（按最终渲染 token 预算）===" in result
     # connection_hint / crystal_hint 是 hints.py 已经拼好的整句提示，不经过
@@ -258,7 +257,6 @@ def test_dream_global_budget_omits_whole_blocks_without_truncating_bodies(
         window_hours=48,
         connection_hint="hint " + "h " * 4000,
         crystal_hint="crystal " + "c " * 4000,
-        core_context=core,
     )
 
     assert dream_output.count_tokens_approx(result) <= budget

--- a/tests/test_pinned_visibility_regression.py
+++ b/tests/test_pinned_visibility_regression.py
@@ -65,7 +65,7 @@ async def test_default_breath_falls_back_to_raw_pinned_content_when_dehydrate_re
 
 
 @pytest.mark.asyncio
-async def test_dream_includes_core_bucket_content_as_reference(bucket_mgr):
+async def test_dream_does_not_surface_pinned_bucket_content(bucket_mgr):
     bucket_id = await bucket_mgr.create(
         content="Pinned dream context must remain visible.",
         pinned=True,
@@ -75,8 +75,9 @@ async def test_dream_includes_core_bucket_content_as_reference(bucket_mgr):
 
     result = await dream_dispatch(window_hours=48)
 
-    assert bucket_id in result
-    assert "Pinned dream context must remain visible" in result
+    assert bucket_id not in result
+    assert "Pinned dream context must remain visible" not in result
+    assert "过去 48 小时内没有需要消化的新记忆" in result
 
 
 @pytest.mark.asyncio

--- a/update_manifest.json
+++ b/update_manifest.json
@@ -817,23 +817,23 @@
     },
     {
       "path": "src/tools/dream/__init__.py",
-      "sha256": "8aaaf823ab683eff5b65d02af114da5fa90f37d108e444a343afe91288232e60",
-      "size": 3072
+      "sha256": "7d729f32f1c29df75a7f20a9f00d614c2138be320c376fa695a817fd87aca3c2",
+      "size": 2928
     },
     {
       "path": "src/tools/dream/candidates.py",
-      "sha256": "198c9bfada3750b3b4ecd4521441fc0ae34eb68b44fcd2140fe252369afc6890",
-      "size": 4084
+      "sha256": "852162fe4713631fd3c46b60177f6b8b51591389eb5abe69287cb5daa77b8511",
+      "size": 4384
     },
     {
       "path": "src/tools/dream/hints.py",
-      "sha256": "38e24ab854039defca936f3732b6555937bf5016b92d0830e3d3e496bb142323",
-      "size": 10974
+      "sha256": "1fd8279e82fd112beec900b8a1ca37e94a7f12790f20074d12ed7e7b056fce4d",
+      "size": 11114
     },
     {
       "path": "src/tools/dream/output.py",
-      "sha256": "afb5a78cf0f544b1c45d7bfe8d4b1eae7044b6b12669f0c9e74959285071527a",
-      "size": 21340
+      "sha256": "c5e5968ad489d6674bb406e2f991206792eec7d69b4df4d4a2171dbe4984d3d6",
+      "size": 19883
     },
     {
       "path": "src/tools/grow/__init__.py",


### PR DESCRIPTION
## Summary`n- stop dream from returning pinned/permanent core-context bodies`n- exclude pinned plan/feel bodies from dream output`n- exclude pinned buckets from I-candidate collision material`n- keep existing bare-memory rendering behavior unchanged for non-pinned content`n`n## Validation`n- tests/test_dream_prompt_boundary.py: 6 passed`n- git diff check passed with repository CRLF handling