### PR TITLE
feat(memory): let hold attach hidden source evidence

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -758,14 +758,17 @@ async def hold(
     media: Optional[list | str] = None,
     test_data: Optional[bool] = False,
     domain: Optional[str] = "",
+    source_content: Optional[str] = "",
+    source_ranges: Optional[list] = None,
 ) -> str:
-    """仅在对话中已明确决定“这段内容值得成为长期记忆”时调用；不要因普通聊天、猜测或工具名称联想而自行调用。content 逐字保存，绝不压缩。title 可选；传入时是最终显式标题，优先于打标模型建议。domain 可选、逗号分隔；显式传入时优先于打标模型结果。系统自动补其余元数据，API 不可用时使用本地中性值继续保存。tags 逗号分隔，importance 1-10。pinned=True 标记为永久核心；feel=True 存为感受类记忆且 domain 固定为 feel。source_bucket 是正在消化的原始记忆桶 ID。why_remembered 与 meaning 是可选的第一人称记录原因。media 可传服务器可读路径或 data_base64+filename 列表项。"""
+    """仅在对话中已明确决定“这段内容值得成为长期记忆”时调用；不要因普通聊天、猜测或工具名称联想而自行调用。content 逐字保存，绝不压缩。title 可选；传入时是最终显式标题，优先于打标模型建议。domain 可选、逗号分隔；显式传入时优先于打标模型结果。系统自动补其余元数据，API 不可用时使用本地中性值继续保存。tags 逗号分隔，importance 1-10。pinned=True 标记为永久核心；feel=True 存为感受类记忆且 domain 固定为 feel。source_bucket 是正在消化的原始记忆桶 ID。source_content/source_ranges 是可选原文证据：由调用方自行决定是否提供；原文进入与 grow 共用的不可变原文层，不参与普通 breath。省略 source_ranges 时整份 source_content 默认属于当前 hold 事件；显式 ranges 使用 1-based 闭区间。why_remembered 与 meaning 是可选的第一人称记录原因。media 可传服务器可读路径或 data_base64+filename 列表项。"""
     return await _with_notice(
         _t_hold.dispatch(
             content=content, title=title, tags=tags, importance=importance,
             pinned=pinned, feel=feel, source_bucket=source_bucket,
             valence=valence, arousal=arousal, why_remembered=why_remembered,
             meaning=meaning, media=media, test_data=test_data, domain=domain,
+            source_content=source_content, source_ranges=source_ranges,
         ),
         op="hold",
         args={
@@ -776,6 +779,8 @@ async def hold(
             "media_count": len(media or []),
             "test_data": bool(test_data),
             "domain": domain,
+            "source_content_len": len(source_content or ""),
+            "source_ranges_count": len(source_ranges or []),
         },
     )
 

--- a/src/tools/breath/_verbatim.py
+++ b/src/tools/breath/_verbatim.py
@@ -4,6 +4,7 @@ This module is intentionally small so the compatibility patch can be removed
 without touching retrieval, ranking, or bucket storage.
 """
 
+from ombrebrain.storage.source_store import normalize_source_refs
 from utils import count_tokens_approx, strip_wikilinks
 
 
@@ -35,6 +36,25 @@ def _miss_block(bucket: dict) -> str:
     return ("\n" + "\n".join(lines)) if lines else ""
 
 
+def source_available_hint(bucket: dict) -> str:
+    """Return a metadata-only hint that hidden source evidence exists.
+
+    The source body remains out of normal surfacing.  A precise title is
+    included when available because source_read requires it explicitly.
+    """
+    meta = bucket.get("metadata", {}) or {}
+    try:
+        refs = normalize_source_refs(meta.get("source_refs") or [])
+    except ValueError:
+        return ""
+    if not refs:
+        return ""
+    title = " ".join(str(meta.get("title") or "").split())
+    if title:
+        return f"[source_available:true | source_title:{title} | use:source_read]"
+    return "[source_available:true | source_read requires an explicit title]"
+
+
 def render_stored_bucket(
     bucket: dict,
     metadata_header: str,
@@ -48,6 +68,9 @@ def render_stored_bucket(
     content = strip_wikilinks(stored_bucket_content(bucket))
     miss_block = _miss_block(bucket)
     rendered = f"{metadata_header}{miss_block}\n{content}"
+    source_hint = source_available_hint(bucket)
+    if source_hint:
+        rendered += f"\n{source_hint}"
     if footprint:
         rendered += f"\n{footprint}"
     return rendered, count_tokens_approx(rendered)

--- a/src/tools/breath/catalog.py
+++ b/src/tools/breath/catalog.py
@@ -21,6 +21,7 @@ breath_search(query=...) 精准拉取需要的记忆——代替把全部记忆�
 
 from .. import _runtime as rt
 from ..plan.core import is_letter_bucket, letter_lock_state
+from ._verbatim import source_available_hint
 from utils import parse_bool
 from errors import safe_error_detail
 
@@ -99,6 +100,10 @@ async def surface_catalog(
             f"{pin_mark}{anchor_mark}{name} | {','.join(domains) or '未分类'} | {imp} "
             f"| {_footprint(b, meta)}"
         )
+        if not letter_locked:
+            source_hint = source_available_hint(b)
+            if source_hint:
+                line += f" | {source_hint}"
         btype = meta.get("type")
         key = "letter" if logical_letter else btype if btype in grouped else "dynamic"
         grouped[key].append((imp, line))

--- a/src/tools/hold/__init__.py
+++ b/src/tools/hold/__init__.py
@@ -23,6 +23,7 @@ core（普通存入 + 自动合并）。
 
 from typing import Optional
 
+from ombrebrain.storage.source_store import normalize_source_ranges
 from utils import normalize_memory_title, parse_bool
 
 from .. import _runtime as rt
@@ -45,6 +46,43 @@ def _normalize_explicit_domain(value: str | list[str] | None) -> list[str] | Non
     return normalized or None
 
 
+def _prepare_source_refs(
+    source_content: object,
+    source_ranges: object,
+) -> tuple[list[dict] | None, str]:
+    """把 hold 可选原文挂到与 grow 共用的不可变 SourceStore。
+
+    hold 是单桶写入：调用方提供原文但省略 ranges 时，整份原文默认就是
+    该桶的 event 证据。显式 ranges 仍使用 grow/source_read 的 1-based 闭区间。
+    """
+    source_text = "" if source_content is None else str(source_content)
+    has_ranges = source_ranges not in (None, "", [])
+    if not source_text.strip():
+        if has_ranges:
+            return None, "source_ranges 需要同时提供 source_content，未创建任何桶。"
+        return None, ""
+
+    try:
+        ranges = normalize_source_ranges(source_ranges)
+    except ValueError as exc:
+        return None, f"原文范围无效，未创建任何桶：{exc}"
+
+    line_count = len(source_text.splitlines()) or 1
+    if not ranges:
+        ranges = [[1, line_count]]
+    elif any(end > line_count for _start, end in ranges):
+        return None, f"source_ranges 超出原文总行数 {line_count}，未创建任何桶。"
+
+    store = getattr(rt, "source_store", None)
+    if store is None:
+        return None, "原文证据存储不可用，未创建任何桶。"
+    try:
+        ref = store.put(source_text)
+    except (OSError, UnicodeError, ValueError) as exc:
+        return None, f"原文证据保存失败，未创建任何桶：{exc}"
+    return [{"ref": ref, "ranges": ranges}], ""
+
+
 async def dispatch(
     content: str,
     title: Optional[str] = "",
@@ -60,6 +98,8 @@ async def dispatch(
     media: Optional[list | str] = None,
     test_data: Optional[bool] = False,
     domain: Optional[str | list[str]] = "",
+    source_content: Optional[str] = "",
+    source_ranges: Optional[list] = None,
 ) -> str:
     content = "" if content is None else str(content)
     try:
@@ -127,6 +167,8 @@ async def dispatch(
         "valence": valence,
         "arousal": arousal,
         "why_remembered_length": len(why_remembered or ""),
+        "source_content_length": len(str(source_content or "")),
+        "source_ranges_count": len(source_ranges or []) if isinstance(source_ranges, list) else 0,
     })
     await rt.decay_engine.ensure_started()
 
@@ -176,12 +218,17 @@ async def dispatch(
     else:
         extra_tags = [t.strip() for t in str(tags).split(",") if t.strip()]
 
+    if feel and (not source_bucket or not source_bucket.strip()):
+        return "feel 必须指向一条原始记忆（source_bucket 不能为空）。请先用 breath_search(query=...) 找到那条桶的 bucket_id，再传入 source_bucket=id。"
+
+    source_refs, source_error = _prepare_source_refs(source_content, source_ranges)
+    if source_error:
+        return source_error
+
     # 所有越界/配额提醒走统一 warnings channel；server.py _with_notice 末尾自动追加。
     # 这里返回值只承载业务正文。
 
     if feel:
-        if not source_bucket or not source_bucket.strip():
-            return "feel 必须指向一条原始记忆（source_bucket 不能为空）。请先用 breath_search(query=...) 找到那条桶的 bucket_id，再传入 source_bucket=id。"
         result = await store_feel(
             content=content,
             title=title,
@@ -192,6 +239,7 @@ async def dispatch(
             why_remembered=why_remembered,
             meaning=meaning,
             media=media,
+            source_refs=source_refs,
         )
         return result
 
@@ -206,6 +254,7 @@ async def dispatch(
             meaning=meaning,
             media=media,
             explicit_domain=explicit_domain,
+            source_refs=source_refs,
         )
         return result
 
@@ -221,5 +270,6 @@ async def dispatch(
         media=media,
         test_data=test_data,
         explicit_domain=explicit_domain,
+        source_refs=source_refs,
     )
     return result

--- a/src/tools/hold/core.py
+++ b/src/tools/hold/core.py
@@ -45,6 +45,7 @@ async def store_core(
     media: list | str | None = None,
     test_data: bool = False,
     explicit_domain: list[str] | None = None,
+    source_refs: list[dict] | None = None,
 ) -> str:
     metadata_fallback = False
     try:
@@ -87,6 +88,7 @@ async def store_core(
         arousal=final_arousal,
         name=suggested_name,
         title=final_title,
+        source_refs=source_refs,
         raw_merge=True,
         why_remembered=why_remembered,
         source_tool="hold",

--- a/src/tools/hold/feel.py
+++ b/src/tools/hold/feel.py
@@ -51,6 +51,7 @@ async def store_feel(
     title: str = "",
     meaning: str = "",
     media: list | None = None,
+    source_refs: list[dict] | None = None,
 ) -> str:
     feel_valence = valence if 0 <= valence <= 1 else 0.5
     feel_arousal = arousal if 0 <= arousal <= 1 else 0.3
@@ -64,6 +65,7 @@ async def store_feel(
         arousal=feel_arousal,
         name=None,
         title=title,
+        source_refs=source_refs,
         bucket_type="feel",
         why_remembered=why_remembered,
         triggered_by=source_bucket.strip() if source_bucket else "",

--- a/src/tools/hold/pinned.py
+++ b/src/tools/hold/pinned.py
@@ -38,6 +38,7 @@ async def store_pinned(
     meaning: str = "",
     media: list | None = None,
     explicit_domain: list[str] | None = None,
+    source_refs: list[dict] | None = None,
 ) -> str:
     try:
         analysis = await rt.dehydrator.analyze(content)
@@ -78,6 +79,7 @@ async def store_pinned(
             arousal=final_arousal,
             name=suggested_name or None,
             title=final_title,
+            source_refs=source_refs,
             bucket_type="permanent",
             pinned=True,
             why_remembered=why_remembered,

--- a/tests/test_breath_verbatim_patch.py
+++ b/tests/test_breath_verbatim_patch.py
@@ -192,6 +192,51 @@ async def test_catalog_still_returns_metadata_without_body(bucket_mgr):
 
 
 @pytest.mark.asyncio
+async def test_breath_marks_hidden_source_evidence_without_inlining_it(
+    bucket_mgr, monkeypatch
+):
+    source_ref = "src_" + "a" * 64
+    body = "只返回这条记忆正文，不自动展开背后的聊天原文。"
+    bucket_id = await bucket_mgr.create(
+        content=body,
+        title="京都计划",
+        domain=["旅行"],
+        importance=8,
+        source_refs=[{"ref": source_ref, "ranges": [[1, 3]]}],
+    )
+    _install_runtime(bucket_mgr)
+    monkeypatch.setattr("tools.breath.search.random.random", lambda: 1.0)
+
+    output = await dispatch(query=bucket_id, max_tokens=10000)
+
+    assert body in output
+    assert "[source_available:true | source_title:京都计划 | use:source_read]" in output
+    assert source_ref not in output
+
+
+@pytest.mark.asyncio
+async def test_catalog_marks_source_availability_without_returning_body(bucket_mgr):
+    source_ref = "src_" + "b" * 64
+    body = "目录里绝不能出现的原文或记忆正文。"
+    await bucket_mgr.create(
+        content=body,
+        name="京都旅行",
+        title="京都旅行",
+        domain=["旅行"],
+        importance=9,
+        source_refs=[{"ref": source_ref, "ranges": [[1, 1]]}],
+    )
+    _install_runtime(bucket_mgr)
+
+    output = await dispatch(catalog=True)
+
+    assert "京都旅行 | 旅行 | 9" in output
+    assert "[source_available:true | source_title:京都旅行 | use:source_read]" in output
+    assert body not in output
+    assert source_ref not in output
+
+
+@pytest.mark.asyncio
 async def test_token_budget_omits_whole_bucket_instead_of_truncating(monkeypatch):
     first = {
         "id": "first",

--- a/tests/test_mcp_tools_docker_integration.py
+++ b/tests/test_mcp_tools_docker_integration.py
@@ -92,6 +92,8 @@ EXPECTED_TOOL_PROPERTIES = {
         "media",
         "test_data",
         "domain",
+        "source_content",
+        "source_ranges",
     },
     "grow": {"content", "items", "test_data"},
     "source_read": {"bucket_id", "expected_title", "scope", "cursor", "max_tokens"},

--- a/tests/test_source_layer.py
+++ b/tests/test_source_layer.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import errno
 import os
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
@@ -285,6 +286,132 @@ async def test_hold_explicit_domain_wins_over_model_suggestion(
     bucket_id = result.split("→", 1)[1].split()[0]
     bucket = await bucket_mgr.get(bucket_id)
     assert bucket["metadata"]["domain"] == ["人工域"]
+
+
+@pytest.mark.asyncio
+async def test_hold_optional_source_content_uses_shared_source_layer(
+    bucket_mgr, monkeypatch
+):
+    class Dehydrator:
+        async def analyze(self, _content):
+            return {
+                "domain": ["旅行"],
+                "valence": 0.8,
+                "arousal": 0.5,
+                "tags": ["京都"],
+                "suggested_name": "京都计划",
+            }
+
+        def invalidate_cache(self, _content):
+            return None
+
+    class Decay:
+        async def ensure_started(self):
+            return None
+
+    store = SourceStore(bucket_mgr.base_dir)
+    monkeypatch.setattr(rt, "config", {"limits": {}, "merge_threshold": 75})
+    monkeypatch.setattr(rt, "bucket_mgr", bucket_mgr)
+    monkeypatch.setattr(rt, "dehydrator", Dehydrator())
+    monkeypatch.setattr(rt, "decay_engine", Decay())
+    monkeypatch.setattr(rt, "source_store", store)
+    monkeypatch.setattr(rt, "logger", MagicMock())
+    monkeypatch.setattr(rt, "fire_webhook", None)
+    monkeypatch.setattr(rt, "mark_op", None)
+
+    source = "第一行：讨论目的地\n第二行：决定去京都\n第三行：约定时间\n"
+    existing_ref = store.put(source)
+    result = await hold(
+        content="我们决定下个月一起去京都。",
+        title="京都计划",
+        source_content=source,
+    )
+    bucket_id = result.split("→", 1)[1].split()[0]
+    bucket = await bucket_mgr.get(bucket_id)
+    refs = bucket["metadata"]["source_refs"]
+
+    assert refs[0]["ref"] == existing_ref
+    assert len(list((Path(bucket_mgr.base_dir) / "_sources").glob("*.source"))) == 1
+    assert refs[0]["ranges"] == [[1, 3]]
+    assert store.read(refs[0]["ref"]) == source
+
+    event = await source_read(bucket_id, "京都计划", scope="event")
+    assert "第一行：讨论目的地" in event
+    assert "第三行：约定时间" in event
+
+
+@pytest.mark.asyncio
+async def test_hold_source_ranges_select_event_and_merge_appends_evidence(
+    bucket_mgr, monkeypatch
+):
+    class Dehydrator:
+        async def analyze(self, _content):
+            return {
+                "domain": ["旅行"],
+                "valence": 0.8,
+                "arousal": 0.5,
+                "tags": [],
+                "suggested_name": "去了京都",
+            }
+
+        def invalidate_cache(self, _content):
+            return None
+
+    class Decay:
+        async def ensure_started(self):
+            return None
+
+    store = SourceStore(bucket_mgr.base_dir)
+    monkeypatch.setattr(rt, "config", {"limits": {}, "merge_threshold": 75})
+    monkeypatch.setattr(rt, "bucket_mgr", bucket_mgr)
+    monkeypatch.setattr(rt, "dehydrator", Dehydrator())
+    monkeypatch.setattr(rt, "decay_engine", Decay())
+    monkeypatch.setattr(rt, "source_store", store)
+    monkeypatch.setattr(rt, "logger", MagicMock())
+    monkeypatch.setattr(rt, "fire_webhook", None)
+    monkeypatch.setattr(rt, "mark_op", None)
+
+    memory = "我们今天真的去了京都。"
+    first = await hold(
+        content=memory,
+        title="去了京都",
+        source_content="前情\n今天到了京都\n去了清水寺\n收尾\n",
+        source_ranges=[[2, 3]],
+    )
+    bucket_id = first.split("→", 1)[1].split()[0]
+    event = await source_read(bucket_id, "去了京都", scope="event")
+    assert "今天到了京都" in event
+    assert "去了清水寺" in event
+    assert "前情" not in event
+    assert "收尾" not in event
+
+    second = await hold(
+        content=memory,
+        title="去了京都",
+        source_content="另一段独立原话",
+    )
+    assert second.startswith("合并→")
+    bucket = await bucket_mgr.get(bucket_id)
+    assert len(bucket["metadata"]["source_refs"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_hold_source_ranges_require_source_content(bucket_mgr, monkeypatch):
+    class Decay:
+        async def ensure_started(self):
+            return None
+
+    monkeypatch.setattr(rt, "bucket_mgr", bucket_mgr)
+    monkeypatch.setattr(rt, "decay_engine", Decay())
+    monkeypatch.setattr(rt, "mark_op", None)
+
+    result = await hold(
+        content="这条不应该写进去。",
+        title="无原文",
+        source_ranges=[[1, 1]],
+    )
+    assert "source_ranges 需要同时提供 source_content" in result
+    assert await bucket_mgr.list_all() == []
 
 
 @pytest.mark.asyncio

--- a/update_manifest.json
+++ b/update_manifest.json
@@ -752,8 +752,8 @@
     },
     {
       "path": "src/server.py",
-      "sha256": "c53d43d31d2b934beec34a26e062c689b7dbbd422afceeb8ec70be1410090f99",
-      "size": 64226
+      "sha256": "9c8ad1740d5f9a9181fe137d332fed023f2f1507733ca4ea35a0f48a6b92c57f",
+      "size": 65014
     },
     {
       "path": "src/server_app.py",
@@ -792,13 +792,13 @@
     },
     {
       "path": "src/tools/breath/_verbatim.py",
-      "sha256": "ffb9f9be38d6c72c3bbae1485a46ce2143872e141a6ec70749f0840216e57a59",
-      "size": 1998
+      "sha256": "1faf46d0d5f69b4a0bf4426eaa1c2def55acea0c49b893ed9befe6f7e31d120e",
+      "size": 2877
     },
     {
       "path": "src/tools/breath/catalog.py",
-      "sha256": "94e9ddd79c827709471fb97a38b0df93d2cdc4b2e5c1e6a5225ce10bd5636259",
-      "size": 5027
+      "sha256": "42426155852ff35577e385065e578cfc2aacb263f0216d082a0ae3b53a00dbac",
+      "size": 5225
     },
     {
       "path": "src/tools/breath/feel.py",
@@ -857,23 +857,23 @@
     },
     {
       "path": "src/tools/hold/__init__.py",
-      "sha256": "1d2d9c943f60012a9b7994c29f701ee1a7866f42b30efe2f4b95843e30ba99b2",
-      "size": 7115
+      "sha256": "5bdd5ec9550b352f82a39f7bdc58f128ec3bc90c6a26704d7c904fd53d893bc8",
+      "size": 9966
     },
     {
       "path": "src/tools/hold/core.py",
-      "sha256": "de6519d17af05b3e0bddedbed20620728a7ab63f9ed4efdba788a808e9680c80",
-      "size": 4131
+      "sha256": "8227c1d7483a6c6af77cf0cc403ea82ba5d678cbea4b23c9e45eaa9e52517ee5",
+      "size": 4372
     },
     {
       "path": "src/tools/hold/feel.py",
-      "sha256": "7ffc2f1015796ee719289d10b98b5c2234206874e2885152c8c8cf49c648a780",
-      "size": 3350
+      "sha256": "f4830ea304e87b1a805f55c77016fe1f1612eb5d10ff23e2a7938d2365222c5c",
+      "size": 3438
     },
     {
       "path": "src/tools/hold/pinned.py",
-      "sha256": "bc3508adba2debddacf7b22b4b37131605427dfdb263985dd20ff6a6f04243ee",
-      "size": 3687
+      "sha256": "bebba793ea0e8c170d5c544e3ff417351d8c7eb9cb6ceda72e4d7a6bd1a81364",
+      "size": 3942
     },
     {
       "path": "src/tools/i/__init__.py",


### PR DESCRIPTION
## What changed

- add optional source_content / source_ranges to hold
- reuse the existing immutable SourceStore used by grow; no new source storage path
- allow normal, pinned, and feel hold branches to attach source refs
- default a hold source without explicit ranges to the full source as this event evidence
- preserve source refs across normal hold merges by appending evidence instead of replacing it
- show a metadata-only source_available hint in breath and catalog when hidden source evidence exists
- keep source bodies and internal source refs hidden until an explicit source_read

## Compatibility

- hold without source arguments behaves exactly as before
- grow logic and storage are unchanged
- identical source text deduplicates to the same content-addressed source file

## Validation

- update_manifest check passed
- 73 passed, 91 skipped across source/grow/breath/MCP integration coverage
- Ruff passed
- compileall passed
- diff check passed with CR-at-EOL handling for existing mixed line endings