### PR TITLE
fix(dream): keep pending I candidates eligible

### DIFF
--- a/docs/INTERNALS.md
+++ b/docs/INTERNALS.md
@@ -436,14 +436,14 @@ Dashboard 的既有 `/api/letter/{letter_id}` PATCH 同时承载两类互斥请�
 
 实现在 `tools/i/`（`dispatch = i_core`）。语义：「我写下关于我自己的认识」——不是「时间里发生的事」，而是模型对自身本质/规律/变化的观察。**`I` 是沉淀物不是日记**：想法先当普通记忆活着，经 dream 反复碰撞后才可能升级进 `I`（哲学边界见 `rule.md` 第 13.1 条）。
 
-- `content` 非空 → **写候选**。创建一条普通 `dynamic` 桶，tag `__i_candidate__`（刻意不是 `__i__`）、`i_stage="candidate"`、`i_dream_dates=[]`。候选照常浮现、衰减、进 dream 窗口——站不住的自然沉下去。`aspect` 可选维度：`nature`(本质) / `values`(看重的) / `patterns`(规律) / `limits`(局限) / `becoming`(在变成什么) / `uncertainty`(不确定的) / `stance`(立场)。
+- `content` 非空 → **写候选**。创建一条普通 `dynamic` 桶，tag `__i_candidate__`（刻意不是 `__i__`）、`i_stage="candidate"`、`i_dream_dates=[]`。候选照常浮现和衰减；在 dream 的普通近期记忆段仍受 `window_hours` 限制，但待沉淀候选段不受该时间窗限制，避免旧候选永久失去三次跨日见证的机会。`aspect` 可选维度：`nature`(本质) / `values`(看重的) / `patterns`(规律) / `limits`(局限) / `becoming`(在变成什么) / `uncertainty`(不确定的) / `stance`(立场)。
 - `content` 空 或 `read=True` → **读取模式**，返回正式条目（按 `limit` 截断，默认 20 条）＋ 待沉淀候选清单；没有 `i_from_candidate` 的历史条目标注为「早期直接写入，未经沉淀」。
 - `promote="桶ID"` → **升级**。要求该候选的 `i_dream_dates` 已有 ≥ `I_PROMOTE_THRESHOLD`（3）个不同日期，否则拒绝并报告还差几次。通过后创建 `type="i"` 桶（`dont_surface=True`、`i_from_candidate`、继承 `i_dream_dates`），候选桶保留原文并改标 `i_stage="promoted"` / `i_promoted_to` / `resolved=True`。同时传 `content` 可用提炼后的措辞落成正式条目。
 - 正式 I 条目带 `dont_surface=True`：**不参与普通 `breath` / `dream`**；只在 `SessionStart` 时自动附带最近 3 条。
 
 dream 侧配合（`tools/dream/hints.py` + `output.py`）：
 
-- `collect_self_candidates(all_buckets, window_hours)` 收集窗口内待沉淀候选，用**已落盘向量**（不发新请求）为每条取相似度 ≥ 0.35 的前 3 条对照材料；对照池 = 全部正式 I 条目 + 全部其它候选 + 最近 200 条普通桶（排除 `letter`）。向量不可用时只列候选并明说。
+- `collect_self_candidates(all_buckets, window_hours)` 收集全部待沉淀候选，不受普通记忆的 `window_hours` 限制；候选按创建时间从旧到新排列，并继续受最终输出 token 预算约束。用**已落盘向量**（不发新请求）为每条取相似度 ≥ 0.35 的前 3 条对照材料；对照池 = 全部正式 I 条目 + 全部其它候选 + 最近 200 条普通桶（排除 `letter`）。向量不可用时只列候选并明说。
 - 专用候选段排在 dream 其它上下文之后，受 `surfacing.dream_max_tokens` 预算约束；候选本身也可能作为普通近期记忆，或作为另一条候选的碰撞材料出现。
 - 见证计数由 `dream/__init__.py` 在最终输出渲染完成后调 `tools.i.record_dream_pass()` 写入，按不同日期去重。只要待沉淀候选的结构化记忆块实际出现在本次输出（近期记忆、候选主块或碰撞材料），就算一次见证；所有位置都因预算未展开时才不计次。
 - 碰撞只摆材料，**不做矛盾/重复判定**（认知层边界，`rule.md` 第 5 条）。

--- a/src/tools/dream/hints.py
+++ b/src/tools/dream/hints.py
@@ -16,8 +16,8 @@ tools/dream/hints.py — dream 的连接提示、结晶提示与 I 候选碰撞�
 关键行为：
 - 都依赖 embedding_engine.enabled；未启用时返回空串 / 空材料并明说
 - protected 只防衰减：连接、结晶、I 候选及碰撞材料一律不读取其正文
-- I 候选的选取并入 candidates.py 近期活跃段的同一套规则：48 小时窗口、
-  排除 pinned、排除 resolved（protected 排除单独保留）
+- I 候选不受普通近期窗口限制；否则候选一旦老于 window_hours，就再也无法
+  获得三次跨日见证。仍排除 pinned / resolved / protected
 - 任意异常都吞掉，只 warning，不影响 dream 主流程
 - 只读已落盘向量，不发新的 embedding 请求
 
@@ -35,7 +35,6 @@ from dataclasses import dataclass, field
 
 from ..i import I_PROMOTE_THRESHOLD, dream_dates, is_pending_candidate
 from .. import _runtime as rt
-from .candidates import is_within_window, recent_window_cutoff
 from ..plan.core import is_letter_bucket
 from utils import parse_bool, strip_wikilinks
 
@@ -160,11 +159,11 @@ def _timestamp_key(bucket: dict) -> str:
 async def collect_self_candidates(all_buckets: list, window_hours: int) -> SelfReview:
     """收集待沉淀的 I 候选，并为每条取几条语义上最挨着的对照材料。
 
-    选取规则并入近期活跃段（candidates.py）的同一套 48 小时窗口、
-    排除 pinned、排除 resolved；protected 排除单独保留。
+    I 候选需要三次跨日见证才能升级，因此不能复用普通记忆的近期窗口；
+    否则过期候选会永久卡住。``window_hours`` 只约束普通 dream 记忆，保留
+    在参数中是为了维持调用契约。候选仍排除 pinned / resolved / protected。
     材料只是材料：支持、反驳、撞车都可能，这里不做任何判定。
     """
-    cutoff = recent_window_cutoff(window_hours)
     pending = [
         b for b in all_buckets
         if is_pending_candidate(b) and not is_letter_bucket(b)
@@ -173,7 +172,6 @@ async def collect_self_candidates(all_buckets: list, window_hours: int) -> SelfR
         )
         and not (b.get("metadata") or {}).get("pinned", False)
         and not (b.get("metadata") or {}).get("resolved", False)
-        and is_within_window(b.get("metadata") or {}, cutoff)
     ]
     if not pending:
         return SelfReview()

--- a/tests/test_i_sediment.py
+++ b/tests/test_i_sediment.py
@@ -221,6 +221,22 @@ async def test_dream_shows_candidates_and_records_one_witness_per_day(env):
 
 
 @pytest.mark.asyncio
+async def test_pending_candidate_outside_recent_window_still_gets_witnessed(env):
+    """A pending I candidate must not become impossible to promote with age."""
+    await i_core.i_core(content="我觉得这条旧候选仍需要完成沉淀。")
+    bucket_id = next(iter(env.buckets))
+    old = "2026-08-01T00:00:00"
+    await env.update(bucket_id, created=old, last_active=old)
+
+    out = await dream.dispatch(window_hours=48)
+
+    assert "我写下的「我觉得」（待沉淀）" in out
+    assert bucket_id in out
+    today = datetime.now().strftime("%Y-%m-%d")
+    assert env.buckets[bucket_id]["metadata"]["i_dream_dates"] == [today]
+
+
+@pytest.mark.asyncio
 async def test_candidate_visible_in_recent_counts_when_i_section_is_omitted(
     env,
     monkeypatch,

--- a/update_manifest.json
+++ b/update_manifest.json
@@ -832,8 +832,8 @@
     },
     {
       "path": "src/tools/dream/hints.py",
-      "sha256": "1fd8279e82fd112beec900b8a1ca37e94a7f12790f20074d12ed7e7b056fce4d",
-      "size": 11114
+      "sha256": "b4f4fdb37854cf13c62b2cfa674b8219009f55546c9a89059c2752e6c7a8af78",
+      "size": 11071
     },
     {
       "path": "src/tools/dream/output.py",


### PR DESCRIPTION
## Motivation

Pending `I` candidates require witnesses from three distinct dream dates before they can be promoted.

Previously, candidate collection also applied the regular dream time window. If a candidate aged out of that window before collecting all three witnesses, it could no longer appear in future dreams and would remain permanently stuck.

## Changes

- Keep pending `I` candidates eligible for dream review regardless of the regular memory time window.
- Preserve the existing filters for pinned, protected, resolved, letter, and non-candidate buckets.
- Preserve oldest-first candidate ordering and the final dream prompt token budget.
- Keep the normal dream-memory segment constrained by `window_hours`.
- Document the behavior and add a regression test for an old pending candidate.

Witness semantics are unchanged: a witness is recorded only when the candidate is actually rendered in the dream prompt, and only one witness per date is counted.

## Tests

- `python -m pytest tests/test_i_sediment.py tests/test_dream_prompt_boundary.py tests/test_comprehensive.py -q`
  - 161 passed
- `ruff check src/tools/dream/hints.py tests/test_i_sediment.py`
  - passed