### PR TITLE
fix(dashboard): preserve search results after bucket refresh

### DIFF
--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -4771,9 +4771,15 @@ async function loadBuckets() {
     selectedBucketIds.forEach(function(id) { if (!liveIds.has(id)) selectedBucketIds.delete(id); });
     updateStats();
     buildFilters();
-    // 数据刷新不等于用户切换视图：继续应用当前筛选，并保留所在页。
+    // 数据刷新不等于用户切换视图：若搜索框里仍有查询，重跑搜索以保持结果视图；
+    // 否则继续应用当前筛选，并保留所在页。
     // 若刷新后页数减少，_paintBuckets 会自动把 bucketPage 收敛到末页。
-    renderBuckets(filterBuckets(allBuckets), true);
+    var activeQuery = (document.getElementById('search-input') || {}).value || '';
+    if (activeQuery.trim()) {
+      await searchBuckets(activeQuery.trim());
+    } else {
+      renderBuckets(filterBuckets(allBuckets), true);
+    }
     if (data.length === 0 && window.ObPet) window.ObPet.react('empty');
   } catch (e) {
     if (generation !== bucketLoadGeneration || requestedSort !== bucketSort) return;

--- a/tests/test_dashboard_bucket_view_state.py
+++ b/tests/test_dashboard_bucket_view_state.py
@@ -27,6 +27,18 @@ def test_bucket_reload_preserves_active_filter_and_page():
     assert "renderBuckets(allBuckets);" not in source
 
 
+def test_bucket_reload_preserves_active_search_results():
+    source = _dashboard_section(
+        "async function loadBuckets()", "function updateStats()"
+    )
+
+    assert "document.getElementById('search-input')" in source
+    assert "if (activeQuery.trim())" in source
+    assert "await searchBuckets(activeQuery.trim());" in source
+    assert "else {" in source
+    assert "renderBuckets(filterBuckets(allBuckets), true);" in source
+
+
 def test_filter_rebuild_restores_active_filter_without_listener_leaks():
     source = _dashboard_section("function buildFilters()", "function filterBuckets(")
 


### PR DESCRIPTION
## 改了什么

修复 Dashboard 在归档/删除搜索结果中的桶后，列表回到“全部桶”的问题。

`loadBuckets()` 刷新数据后会检查搜索框：

- 查询词非空时重新执行 `searchBuckets()`，保留当前搜索结果视图；
- 查询词为空时继续恢复原有 filter 与页码。

同时补充 Dashboard 视图状态回归测试。

Fixes #108

## 为什么这么改

问题并不在搜索 API 或部署配置，而在刷新后的前端渲染路径：原逻辑无条件执行 `renderBuckets(filterBuckets(allBuckets), true)`，只恢复 filter/page，没有恢复仍显示在输入框里的搜索查询。

读取现有搜索框值并重跑搜索，能够让 UI 状态与可见输入保持一致，也自然覆盖归档、批量归档及其他会调用 `loadBuckets()` 的写操作。搜索框为空时保持既有行为，不改变普通筛选与分页语义。

## 测过没有

使用真实 `frontend/dashboard.html`、JSDOM 和假后端走完整交互序列：

```text
原始 main：A+B 搜索结果中删除 A → 错误显示 B+C
应用修复：A+B 搜索结果中删除 A → 正确只显示 B
```

Focused tests：

```text
PYTHONPATH=/workspace/.testdeps python3 -m pytest \
  tests/test_dashboard_bucket_view_state.py \
  tests/test_dashboard_auth_flow.py -q

25 passed
```

---

- [x] 我的提交都带了 `Signed-off-by:`（`git commit -s`），表示我有权提交这些代码
- [x] 没有把真实记忆内容、API Key、密码带进这个 PR
