### PR TITLE
fix(breath): make surfacing diversity configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -695,6 +695,9 @@ docker compose -f deploy/docker-compose.yml up -d
 | `embedding.retry_base_seconds` / `retry_max_seconds` | 向量失败后的指数退避起点 / 上限 | `5` / `300` |
 | `decay.lambda` | 衰减速率，越大越快忘 | `0.05` |
 | `merge_threshold` | 合并相似度阈值 (0-100) | `75` |
+| `surfacing.breath_max_results` | 每次 `breath()` 的主要浮现硬上限；采样开启时普通主候选还受 `sample_k` 限制 | `20` |
+| `surfacing.cold_start_max_results` | 从未访问且 importance≥8 的桶强制插队数；`0` 同时取消这类桶因冷启动身份进入「久未浮现」，但仍可作为普通候选被抽中 | `2`（范围 `0～2`） |
+| `surfacing.sampling.enabled` | 是否从 `top_k` 候选池加权抽出最多 `sample_k` 条普通主候选；开启后不再固定保留 Top-1 | `false`；需要降低重复时开启 |
 | `hooks.token` | `/breath-hook` 的 HTTP token | 自托管公网建议设置 |
 | `hooks.allow_public` | 是否允许 hook 无鉴权访问 | `false` |
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -188,13 +188,14 @@ surfacing:
   breath_max_results: 20          # 1-50, hard cap of buckets returned per breath
   breath_max_tokens: 10000        # 500-40000, total token cap per breath; 40000 is a safety ceiling, not the default
   feel_max_tokens: 15000          # 500-20000, full-text budget for feel history; older feels collapse to one-line summaries
+  cold_start_max_results: 2       # 0-2; 0 disables unvisited-identity priority/passive surfacing, but keeps those buckets as normal candidates
   # iter 1.8: weighted sampling for breath surfacing mode（无参数浮现）
   # 加权采样：从 top_k 候选里按 score**(1/temperature) 抽 sample_k 个，让"想起"带轻微随机性。
   # 测试 fixture 里默认关 (enabled=false)，保证排序确定。生产可以开。
   sampling:
     enabled: false                # true = 启用加权采样；false = 退化为 top1+shuffle 原行为
     top_k: 5                      # 候选池大小
-    sample_k: 2                   # 抽出几个
+    sample_k: 2                   # 每次最多返回的普通主候选数（另受 top_k 与 breath_max_results 上限约束）
     temperature: 0.7              # >1 更平均、<1 更偏向高分；0.7 是个温和的默认
 
 # --- Limits / 边界限制（iter 1.6 §5）---

--- a/docs/INTERNALS.md
+++ b/docs/INTERNALS.md
@@ -295,7 +295,7 @@ feel 桶自身：
 2. **Plan 通道**（`domain="plan"`，仅 `breath_advanced`，3.0.0 新增）：直接拉所有 `type==plan && status==active` 桶，按 `created` 倒序逐字返回，放不下的整条省略、不截断不摘要；一条 active plan 都没有时返回「没有计划。」。
    > **为什么必须有这个通道**：plan 桶被浮现模式排除，而 `domain` 参数只在 catalog 模式和检索模式（模式 5，需要 `query`）里生效。没有这一分流时，`breath_advanced(domain="plan")` 会落到模式 4 浮现模式，返回权重最高的桶 + 置顶核心准则——**调用方拿到的是核心准则，不是 plan**。叠加 dream 末尾 plan 段可能因总预算降级成只报条数，plan 正文一度没有任何读取入口。回归测试见 `tests/test_breath_plan_channel.py`。
 3. **重要度批量模式**（`importance_min >= 1`，仅 `breath_advanced`）：跳过语义搜索，按 importance 降序返回 ≤20 条；过滤 `feel/plan/letter` 与 `dont_surface=True`；**不过滤 anchor、不过滤 pinned**（设计：主动按 importance 检索时希望能找到所有重要桶）。
-4. **浮现模式**（无 `query`；`breath()` 固定走这里）：pinned/显式 permanent 桶展示为「核心准则」+ 未解决桶按衰减分排序，**冷启动**（`activation_count==0 && importance>=8`）的桶最多 2 个插到最前；后续排序**有两条互斥路径**：当 `surfacing.sampling.enabled=true` 时走加权无放回采样（`top_k` / `sample_k` / `temperature` 控制；详见 §7.1），否则走原 Top-1 固定 + Top-2~20 随机洗牌；按 `max_results` 硬截断。**排除 anchor 与 protected 桶**：anchor 是坐标系；protected 只防衰减，不进入核心准则、未解决、久未浮现或偶遇池。浮现**不调用** `touch()`。每条返回正文后附一行紧凑 `👣 Footprint`，只表达创建、补充、淡去、归档、恢复等有意义的变迁，不展示 touch/索引噪声。**末尾追加 `=== 久未浮现 ===` 段**：从久未激活的高重要度桶里随机抽 1～2 条，模拟「突然想起来」。
+4. **浮现模式**（无 `query`；`breath()` 固定走这里）：pinned/显式 permanent 桶展示为「核心准则」+ 未解决桶按衰减分排序。**冷启动**（`activation_count==0 && importance>=8`）插队数由 `surfacing.cold_start_max_results` 控制（默认 2、范围 0～2）；设为 0 会同时取消这类桶因「从未访问」而进入主区固定席位及「久未浮现」段的特殊待遇，但仍保留普通候选资格。后续排序**有两条互斥路径**：当 `surfacing.sampling.enabled=true` 时，从得分前 `top_k` 的普通候选池按权重无放回抽出并**只返回**最多 `sample_k` 条（不再固定 Top-1；详见 §7.1）；否则走原 Top-1 固定 + Top-2~20 随机洗牌。冷启动席位与抽样结果合计仍受 `max_results` 硬上限约束。**排除 anchor 与 protected 桶**：anchor 是坐标系；protected 只防衰减，不进入核心准则、未解决、久未浮现或偶遇池。浮现**不调用** `touch()`。每条返回正文后附一行紧凑 `👣 Footprint`，只表达创建、补充、淡去、归档、恢复等有意义的变迁，不展示 touch/索引噪声。**末尾追加 `=== 久未浮现 ===` 段**：从久未激活的高重要度桶里随机抽 1～2 条，模拟「突然想起来」；当冷启动上限为 0 时，单凭「从未访问」不再满足此段条件。
 5. **检索模式**（有 `query`；`breath_search()` 固定走这里）：每个 query 只生成一次查询向量，与 rapidfuzz/BM25 多维评分共同进入 `BucketManager.search()` → 过滤 `feel/plan/letter`，**pinned/permanent/protected 仍可被显式检索命中**：pinned/permanent 加 `📌 [核心准则]`，protected 加 `🛡️ [受保护记忆]` → 纯语义候选相似度 `>=0.65` 标 `[语义关联]`，且不能绕过 domain/tags/type 过滤 → 活跃桶命中时 `touch()`。查询也会检索 archive；归档命中返回保留的 Markdown 原文与 Footprint，明确邀请模型判断是否值得再次回忆，并显示 `trace(bucket_id="...", restore=True)`。查询只发现、不自动恢复，也不 touch 归档桶。结果不足时保留设计上的自由联想，但 protected 不进入这一非命中随机通道。embedding 不可用时明确提示后继续关键词/BM25；桶一旦命中，返回层直接使用当前存储的完整 `content`，不调用 dehydrate、不剥除 wikilink、不截断或改写。**不过滤 anchor**（设计：主动检索时希望能找到坐标系桶）。catalog 同样保留 protected 并使用相同的受保护标记。
 
 #### 检索的门：召回与排序目前没有分开（已知设计债）
@@ -543,7 +543,7 @@ dream 侧配合（`tools/dream/hints.py` + `output.py`）：
 | `/api/bucket/{id}/archive` | POST | 🔒 | 软删除（移入 archive/） |
 | `/api/bucket/{id}/forget` | POST | 🔒 | iter 1.8：切换 `dont_surface`。桶仍在磁盘，只是不再被无参 `breath()` 主动浮现，关键词搜索仍可达 |
 | `/api/buckets/forget` | POST | 🔒 | iter 1.9：批量设置 `dont_surface`。Body `{ids:[...], dont_surface: bool}`。返回 `{ok, updated:[], missing:[], errors:[]}` |
-| `/api/settings/sampling` | GET / POST | 🔒 | iter 1.9：dashboard 的加权采样面板。GET 返回当前 `surfacing.sampling.{enabled,top_k,sample_k,temperature}`；POST 校验范围后热更新到内存 config（不写回 yaml） |
+| `/api/settings/sampling` | GET / POST | 🔒 | iter 1.9：dashboard 的加权采样面板。GET 返回当前 `surfacing.sampling.{enabled,top_k,sample_k,temperature}`；POST 校验范围后同时热更新运行态并原子持久化到 yaml |
 | `/api/anchors` | GET | 🔒 | iter 2.0：列出所有 anchor 桶（按 `created` 升序），返回 `{ok, count, limit, anchors:[...]}` |
 | `/api/bucket/{id}/anchor` | POST | 🔒 | iter 2.0：toggle anchor 标记。Body 可传 `{value: bool}` 强制设置；不传则切换。已满 24 时返回 **409** + `{error, count, limit}` |
 | `/api/bucket/{id}` | DELETE | 🔒 | 删除到档案：移入 `archive/` 并写 `deleted_at`，需 `?confirm=true`；不做物理抹除 |
@@ -1518,11 +1518,12 @@ normalized = total / w_sum × 100   # 归一化到 0~100
 | `surfacing.breath_max_tokens` | `10000` | 覆盖 `breath` 默认 max_tokens |
 | `surfacing.breath_max_results` | `20` | 覆盖 `breath` 默认 max_results |
 | `surfacing.feel_max_tokens` | `15000` | **dream** feel 历史段的 token 预算，超出折叠为 60 字摘要。3.0.0 起不再作用于 feel 通道——`feel(query=...)` 用自己的 `max_tokens`（默认 10000），且放不下时整条省略、不折叠 |
+| `surfacing.cold_start_max_results` | `2` | 0～2；控制「从未访问且 importance>=8」桶的主区插队数。设为 0 同时取消这类桶因未访问身份进入被动联想，但仍保留普通候选资格 |
 | `timezone` | `Asia/Shanghai` | 3.0.0：用户只给日期、不写时区时按它理解（Letter 定时锁 `unlock_date` 等）。IANA 时区名；名字非法或缺 tzdata 时回退固定 `+08:00`，但 Dashboard 保存会当场校验拒绝。Dashboard「设置」可改，热更新生效 |
 | `ai_name` | （空） | 3.0.0：AI 一方的显示名。优先级高于环境变量 `AI_NAME`；随 vault 持久化，容器重建不丢。留空=未配置，回退环境变量再回退 `"AI"` |
 | `surfacing.sampling.enabled` | `false` | 浮现模式加权采样总开关；false 走原 Top-1 + shuffle |
 | `surfacing.sampling.top_k` | `5` | 候选池大小（按衰减分取前 k） |
-| `surfacing.sampling.sample_k` | `2` | 从池里无放回抽 k 条返回 |
+| `surfacing.sampling.sample_k` | `2` | 从前 `top_k` 池里无放回抽样，并只返回最多 k 条普通主候选；另受 `breath_max_results` 上限约束 |
 | `surfacing.sampling.temperature` | `0.7` | 权重 = score^(1/temperature)；>1 更均匀，<1 更偏向高分桶 |
 | `wikilink.*` | （已废弃） | wikilink 自动注入已禁用，由 LLM prompt 直接生成 `[[]]`；`config.example.yaml` 不再给出可配置项 |
 
@@ -1587,7 +1588,7 @@ normalized = total / w_sum × 100   # 归一化到 0~100
 |---|---|---|
 | `10000` / `40000` | `breath` | max_tokens 默认 / 显式 opt-in 安全上限（非新默认） |
 | `20` / `50` | `breath` | max_results 默认 / 上限 |
-| `2` | `breath` 浮现 | 冷启动桶数上限 |
+| `2`（默认，可设 `0～2`） | `breath` 浮现 | `surfacing.cold_start_max_results` 冷启动桶数上限；0 关闭特殊待遇 |
 | `8` | 冷启动 | importance >= 8 才进入冷启动 |
 | `20` | `breath` 浮现 | top-1 固定 + top-2~20 随机 |
 | `0.65` | `breath` 检索 | 纯语义候选进入结果池的余弦相似度下限 |
@@ -1684,7 +1685,7 @@ normalized = total / w_sum × 100   # 归一化到 0~100
 | 向量搜索没生效 | `embedding_engine.py` + `tools/breath/search.py` | `enabled` 是否为 True；`search_similar_strict` 是否触发降级提示；用 `tools/evaluate_retrieval.py --with-embedding` 对比基线 |
 | 向量后端切换不生效 | `web/config_api.py` | `/api/config` POST 中 embedding.backend 分支必须 `EmbeddingEngine(config)` 完整重建 |
 | `feel(query=...)` 返回空但有 feel 桶 | `bucket_manager.py` | `list_all()` `dirs` 列表必须含 `self.feel_dir`；另确认关键词是否真的与任何 feel 相关（阈值 0.65） |
-| Top-1 永远是同一个桶 | `tools/breath/` | 浮现分支 `top1` 固定逻辑；想加多样性需改成 sampling |
+| 连续 breath 的 Top-1 永远是同一个桶 | `tools/breath/` | 确认 `surfacing.sampling.enabled=true`，并让 `sample_k` 小于候选池规模；启用后只返回抽中的子集，不固定 Top-1 |
 
 ### 11.2 存储 / 合并类
 
@@ -1755,7 +1756,7 @@ normalized = total / w_sum × 100   # 归一化到 0~100
 
 9. **Dashboard 对普通桶只提供一个经人类发起的「归档」入口**。该入口要求理由并进入 AI 删除审批；批准后移入 `archive/`、写 `deleted_at`。底层 `archive()` 仍保留给 AI/系统生命周期逻辑，且不写删除标记。兼容 DELETE 端点仍执行删除到档案；物理删除 UI 已移除，旧 `/api/buckets/purge` 仅返回 410。
 
-10. **冷启动检测最多 2 个**。`importance >= 8` 的新桶超过 2 个时，第 3 个开始按普通衰减分排队，可能被压在 top-20 后随机洗牌。如果用户一次性钉选 5 条核心准则后又新建 3 个 importance=10 的事件桶，会感到「我刚建的核心事件没浮现」。
+10. **冷启动检测默认最多 2 个，可设为 0～2**。`surfacing.cold_start_max_results=0` 会取消新高重要度桶因「从未访问」身份获得的固定席位与被动联想资格；它们仍按普通衰减分参与候选。若设为 1 或 2，超出席位的第 2／3 个以后也同样按普通候选排队。
 
 11. **Letter 不参与压缩但仍生成 embedding**。原文如果非常长（>2000 字符）embedding 只看前 2000 字符——长信件的语义检索会偏向开头。这是已知 trade-off，未来若需要可改为分段 embedding。
 

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -2846,7 +2846,7 @@
         <div style="font-weight:600;font-size:13px;margin-bottom:6px;">呼吸采样 <span style="font-size:11px;color:var(--text-dim);font-weight:400;">/ Breath Sampling</span></div>
         <div style="font-size:12px;color:var(--text-dim);margin-bottom:10px;line-height:1.7;">
           <b>关</b>：breath 永远返回得分最高的那条。<br>
-          <b>开</b>：按 score^(1/温度) 加权采样，中等分数的桶也有机会浮现（温度越高越随机；候选不足时自动回退）。
+          <b>开</b>：从 top_k 候选池按 score^(1/温度) 加权抽出最多 sample_k 条；中等分数的桶也有机会浮现（温度越高越随机）。
         </div>
         <div class="config-row" style="align-items:center;">
           <label>启用加权采样</label>
@@ -2867,7 +2867,7 @@
         </div>
         <div style="display:flex;gap:8px;align-items:center;margin-top:6px;">
           <button class="btn-primary" onclick="saveSamplingSettings()" title="保存 / Save" style="padding:0 14px;height:36px;display:inline-flex;align-items:center;gap:5px;"><i data-lucide="check"></i> 保存 Save</button>
-          <button onclick="testSamplingBreath()" title="试一次 breath / Try a breath" style="font-size:12px;padding:0 12px;height:36px;display:inline-flex;align-items:center;gap:5px;"><i data-lucide="wind"></i> 试Breath</button>
+          <button onclick="previewBreathScores()" title="仅查看当前评分前五，不模拟随机 breath" style="font-size:12px;padding:0 12px;height:36px;display:inline-flex;align-items:center;gap:5px;"><i data-lucide="list-ordered"></i> 查看评分前五</button>
           <span id="sampling-msg" style="font-size:12px;"></span>
         </div>
         <div id="sampling-test-result" style="margin-top:10px;font-size:12px;color:var(--text-dim);"></div>
@@ -2879,6 +2879,8 @@
         <div style="margin-top:-4px;padding-left:122px;font-size:11px;color:var(--text-light);">0-100，越高越难合并相似桶</div>
         <div class="config-row"><label>breath 默认桶数</label><input type="number" id="cfg-sf-breath-results" min="1" max="50" /></div>
         <div style="margin-top:-4px;padding-left:122px;font-size:11px;color:var(--text-light);">1-50。AI 调用 breath() 不指定 max_results 时使用此默认值</div>
+        <div class="config-row"><label>冷启动保留席位</label><input type="number" id="cfg-sf-cold-start-results" min="0" max="2" step="1" /></div>
+        <div style="margin-top:-4px;padding-left:122px;font-size:11px;color:var(--text-light);">0-2。设为 0 会取消「从未访问」身份的主区插队与被动联想；这些桶仍可作为普通候选被抽中</div>
         <div class="config-row"><label>breath 默认 token</label><input type="number" id="cfg-sf-breath-tokens" min="500" max="40000" step="500" /></div>
         <div style="margin-top:-4px;padding-left:122px;font-size:11px;color:var(--text-light);">500-40000。breath 单次返回总 token 上限；40000 为安全上限，不是默认值</div>
         <div class="config-row"><label>feel 历史 token</label><input type="number" id="cfg-sf-feel-tokens" min="500" max="20000" step="500" /></div>
@@ -4371,7 +4373,7 @@ async function saveSamplingSettings() {
     const d = await readJsonSafe(resp);
     if (resp.ok) {
       msg.style.color = 'var(--accent)';
-      msg.textContent = '已保存（仅热更新到内存）';
+      msg.textContent = '已保存并持久化';
     } else {
       msg.style.color = 'var(--negative)';
       msg.textContent = d.error || '保存失败';
@@ -4382,9 +4384,9 @@ async function saveSamplingSettings() {
   }
 }
 
-async function testSamplingBreath() {
+async function previewBreathScores() {
   const out = document.getElementById('sampling-test-result');
-  out.textContent = 'breath 中…';
+  out.textContent = '读取评分中…';
   try {
     const resp = await authFetch('/api/breath?n=5');
     if (!resp) return;
@@ -4394,7 +4396,7 @@ async function testSamplingBreath() {
       out.textContent = '没有候选桶（库可能是空的）';
       return;
     }
-    out.innerHTML = '本次浮现：<br/>' + items.map((b, i) => {
+    out.innerHTML = '当前评分前五（不是随机 breath 结果）：<br/>' + items.map((b, i) => {
       const nm = esc(b.name || b.id || '(无名)');
       const sc = (b.score != null) ? ' · ' + Number(b.score).toFixed(3) : '';
       return (i + 1) + '. ' + nm + sc;
@@ -7340,6 +7342,7 @@ async function loadConfig() {
     }
     var sf = cfg.surfacing || {};
     document.getElementById('cfg-sf-breath-results').value = sf.breath_max_results || 20;
+    document.getElementById('cfg-sf-cold-start-results').value = sf.cold_start_max_results != null ? sf.cold_start_max_results : 2;
     document.getElementById('cfg-sf-breath-tokens').value = sf.breath_max_tokens || 10000;
     document.getElementById('cfg-sf-feel-tokens').value = sf.feel_max_tokens || 15000;
     document.getElementById('cfg-timezone').value = cfg.timezone || 'Asia/Shanghai';
@@ -7616,8 +7619,15 @@ async function saveEmbedKey() {
 async function saveConfig(persist) {
   var dehyTemperatureRaw = document.getElementById('cfg-dehy-temp').value.trim();
   var mergeThresholdRaw = document.getElementById('cfg-merge').value.trim();
+  var coldStartRaw = document.getElementById('cfg-sf-cold-start-results').value.trim();
   var dehyTemperature = dehyTemperatureRaw === '' ? NaN : Number(dehyTemperatureRaw);
   var mergeThreshold = mergeThresholdRaw === '' ? NaN : Number(mergeThresholdRaw);
+  var coldStartMaxResults = coldStartRaw === '' ? 2 : Number(coldStartRaw);
+  var status = document.getElementById('config-status');
+  if (coldStartRaw !== '' && (!Number.isInteger(coldStartMaxResults) || coldStartMaxResults < 0 || coldStartMaxResults > 2)) {
+    status.innerHTML = '<span style="color:var(--negative)">' + _SV.err + ' 冷启动保留席位必须是 0 到 2 的整数</span>';
+    return;
+  }
   var body = {
     dehydration: {
       model: document.getElementById('cfg-dehy-model').value,
@@ -7638,11 +7648,11 @@ async function saveConfig(persist) {
       breath_max_results: parseInt(document.getElementById('cfg-sf-breath-results').value) || 20,
       breath_max_tokens: parseInt(document.getElementById('cfg-sf-breath-tokens').value) || 10000,
       feel_max_tokens: parseInt(document.getElementById('cfg-sf-feel-tokens').value) || 15000,
+      cold_start_max_results: coldStartRaw === '' ? 2 : coldStartMaxResults,
     },
     timezone: (document.getElementById('cfg-timezone').value || '').trim(),
     persist: persist,
   };
-  var status = document.getElementById('config-status');
   try {
     var res = await authFetch('/api/config', {
       method: 'POST',

--- a/src/tools/breath/surface.py
+++ b/src/tools/breath/surface.py
@@ -11,10 +11,12 @@ tools/breath/surface.py — 无 query 浮现模式
 - 排除 digested 桶（已消化记忆只允许显式检索/审计找回）
 - 通过主动浮现策略的 pinned/permanent 桶作为「核心准则」置顶
 - protected 只防衰减，不进入核心准则、未解决池、被动联想或偶遇池
-- 未解决桶按 calculate_score 排序；冷启动桶（从未访问且 importance>=8）插队前 2
-- 配置开关 surfacing.sampling.enabled 启用后做加权无放回采样，否则
-  保留 top1 + top20 内随机洗牌
-- 末尾 1~2 条「久未浮现」passive association（imp>=8 且未访问 / imp>=9 且 7 天未活跃）
+- 未解决桶按 calculate_score 排序；冷启动桶（从未访问且 importance>=8）的插队数由
+  surfacing.cold_start_max_results 控制（默认 2；0 关闭该身份的特殊待遇）
+- 配置开关 surfacing.sampling.enabled 启用后，从 top_k 候选池加权无放回抽出并只返回
+  最多 sample_k 条普通主候选；否则保留 top1 + top20 内随机洗牌
+- 末尾 1~2 条「久未浮现」passive association（imp>=8 且未访问 / imp>=9 且 7 天未活跃）；
+  cold_start_max_results=0 时，单凭“未访问”不再进入该段
 
 不做什么（边界）：
 - 不调用 touch()：浮现不能重置衰减计时器
@@ -260,11 +262,26 @@ async def surface_default(max_results: int, max_tokens: int, tag_filter: list) -
         rt.logger.info(f"Top unresolved scores: {top_scores}")
 
     # --- 冷启动检测 ---
+    raw_cold_start_max = surfacing_cfg.get("cold_start_max_results", 2)
+    try:
+        if isinstance(raw_cold_start_max, bool):
+            raise ValueError("boolean is not an integer count")
+        cold_start_max_results = int(raw_cold_start_max)
+        if isinstance(raw_cold_start_max, float) and not raw_cold_start_max.is_integer():
+            raise ValueError("fractional count")
+        if not 0 <= cold_start_max_results <= 2:
+            raise ValueError("outside 0..2")
+    except (TypeError, ValueError):
+        rt.logger.warning(
+            "Invalid surfacing.cold_start_max_results=%r; fallback to 2",
+            raw_cold_start_max,
+        )
+        cold_start_max_results = 2
     cold_start = [
         b for b in unresolved
         if int(b["metadata"].get("activation_count") or 0) == 0
         and int(b["metadata"].get("importance") or 0) >= 8
-    ][:2]
+    ][:cold_start_max_results]
     cold_start_ids = {b["id"] for b in cold_start}
     scored_deduped = [b for b in scored if b["id"] not in cold_start_ids]
     scored_with_cold = cold_start + scored_deduped
@@ -279,7 +296,7 @@ async def surface_default(max_results: int, max_tokens: int, tag_filter: list) -
         top_k = int(sampling_cfg.get("top_k") or 5)
         sample_k = int(sampling_cfg.get("sample_k") or 2)
         temperature = max(0.1, float(sampling_cfg.get("temperature") or 0.7))
-        pool = non_cold[:max(top_k, sample_k)]
+        pool = non_cold[:top_k]
         try:
             weights = [
                 max(0.0001, rt.decay_engine.calculate_score(b["metadata"])) ** (1.0 / temperature)
@@ -292,9 +309,9 @@ async def surface_default(max_results: int, max_tokens: int, tag_filter: list) -
                 idx = random.choices(range(len(pool_copy)), weights=weights_copy, k=1)[0]
                 picked.append(pool_copy.pop(idx))
                 weights_copy.pop(idx)
-            rest = pool_copy + non_cold[len(pool):]
-            non_cold = picked + rest
-            candidates = cold_start + non_cold
+            # Sampling is a returned subset, not merely a permutation of the
+            # same top-N set.  This is what lets consecutive breaths vary.
+            candidates = cold_start + picked
         except Exception as e:
             rt.logger.warning(f"Weighted sampling failed, fallback to original / 加权采样失败: {e}")
     elif len(candidates) > 1:
@@ -383,7 +400,9 @@ async def surface_default(max_results: int, max_tokens: int, tag_filter: list) -
             meta = b["metadata"]
             ac = int(meta.get("activation_count") or 0)
             imp = int(meta.get("importance") or 0)
-            cond_a = ac == 0 and imp >= 8
+            # A zero cap disables the special "unvisited" identity everywhere.
+            # The same bucket still remains eligible in the ordinary main pool.
+            cond_a = cold_start_max_results > 0 and ac == 0 and imp >= 8
             cond_b = False
             if imp >= 9:
                 last = meta.get("last_active") or meta.get("created", "")

--- a/src/web/buckets.py
+++ b/src/web/buckets.py
@@ -668,11 +668,10 @@ def register(mcp) -> None:
 
 
     # ---- iter 1.9 B: dashboard 调 sampling 配置 / sampling control ----
-    # GET 返回当前 surfacing.sampling；POST 接收新值并热更新内存里的 config。
-    # 这里只改运行时 config，不写回 yaml—— yaml 持久化交给 1.6 已有的设置面板机制（如开发者愿意手 sync）。
+    # GET 返回当前 surfacing.sampling；POST 校验后原子写入 YAML，再发布到运行时 config。
     @mcp.custom_route("/api/settings/sampling", methods=["GET", "POST"])
     async def api_settings_sampling(request: Request) -> Response:
-        """Get / hot-update breath weighted sampling settings (iter 1.9 §B)."""
+        """Get or persist breath weighted sampling settings (iter 1.9 §B)."""
         from starlette.responses import JSONResponse
         err = sh._require_auth(request)
         if err:

--- a/src/web/config_api.py
+++ b/src/web/config_api.py
@@ -277,6 +277,20 @@ def register(mcp) -> None:
         )
         api_key = dehy.get("api_key", "")
         masked_key = f"{api_key[:4]}...{api_key[-4:]}" if len(api_key) > 8 else ("***" if api_key else "")
+        surfacing = sh.config.get("surfacing", {}) or {}
+        try:
+            cold_start_max_results = _bounded_config_int(
+                surfacing.get("cold_start_max_results", 2),
+                "surfacing.cold_start_max_results",
+                0,
+                2,
+            )
+        except ValueError:
+            logger.warning(
+                "invalid runtime surfacing.cold_start_max_results=%r; fallback to 2",
+                surfacing.get("cold_start_max_results"),
+            )
+            cold_start_max_results = 2
         return JSONResponse({
             "dehydration": {
                 "model": dehy.get("model", ""),
@@ -298,9 +312,10 @@ def register(mcp) -> None:
                 ],
             },
             "surfacing": {
-                "breath_max_results": int(sh.config.get("surfacing", {}).get("breath_max_results") or 20),
-                "breath_max_tokens": int(sh.config.get("surfacing", {}).get("breath_max_tokens") or 10000),
-                "feel_max_tokens": int(sh.config.get("surfacing", {}).get("feel_max_tokens") or 15000),
+                "breath_max_results": int(surfacing.get("breath_max_results") or 20),
+                "breath_max_tokens": int(surfacing.get("breath_max_tokens") or 10000),
+                "feel_max_tokens": int(surfacing.get("feel_max_tokens") or 15000),
+                "cold_start_max_results": cold_start_max_results,
             },
             "merge_threshold": sh.config.get("merge_threshold", 75),
             # 只给日期不写时区时按它理解（Letter 定时锁等）。前端「设置」可改。
@@ -472,6 +487,7 @@ def register(mcp) -> None:
                 ("breath_max_results", 1, 50),
                 ("breath_max_tokens", 500, 40000),
                 ("feel_max_tokens", 500, 20000),
+                ("cold_start_max_results", 0, 2),
             ):
                 if key in surfacing_payload:
                     surfacing_values[key] = _bounded_config_int(

--- a/tests/test_breath_cold_start.py
+++ b/tests/test_breath_cold_start.py
@@ -1,0 +1,231 @@
+"""Configurable cold-start priority for default breath surfacing."""
+
+import re
+from unittest.mock import MagicMock
+
+import pytest
+
+import tools._runtime as rt
+from tools.breath.surface import surface_default
+
+
+class NoopDecay:
+    def calculate_score(self, meta):
+        return float(meta.get("importance") or 5)
+
+
+class OrderedBucketManager:
+    def __init__(self, buckets):
+        self.buckets = list(buckets)
+
+    async def list_all(self, include_archive=False):
+        return list(self.buckets)
+
+
+def _bucket(bucket_id: str, importance: int, activation_count: int) -> dict:
+    return {
+        "id": bucket_id,
+        "content": f"content for {bucket_id}",
+        "metadata": {
+            "type": "dynamic",
+            "importance": importance,
+            "activation_count": activation_count,
+            "domain": [],
+        },
+    }
+
+
+def _install_runtime(buckets, cold_start_max_results):
+    surfacing = {}
+    if cold_start_max_results is not None:
+        surfacing["cold_start_max_results"] = cold_start_max_results
+    rt.config = {"surfacing": surfacing}
+    rt.bucket_mgr = OrderedBucketManager(buckets)
+    rt.decay_engine = NoopDecay()
+    rt.logger = MagicMock()
+    rt.fire_webhook = None
+    rt.mark_op = None
+
+
+def _primary_ids(output: str) -> list[str]:
+    primary = output.split("=== 浮现记忆 ===\n", 1)[1]
+    primary = primary.split("\n\n=== ", 1)[0]
+    return re.findall(r"\[bucket_id:([^\]]+)\]", primary)
+
+
+@pytest.mark.parametrize(
+    ("configured_limit", "max_results", "expected_ids"),
+    [
+        (0, 1, ["high"]),
+        (1, 2, ["cold-a", "high"]),
+        (2, 3, ["cold-a", "cold-b", "high"]),
+        (None, 3, ["cold-a", "cold-b", "high"]),
+    ],
+)
+@pytest.mark.asyncio
+async def test_cold_start_priority_count_is_configurable(
+    monkeypatch, configured_limit, max_results, expected_ids
+):
+    buckets = [
+        _bucket("cold-a", importance=8, activation_count=0),
+        _bucket("cold-b", importance=8, activation_count=0),
+        _bucket("high", importance=10, activation_count=1),
+        _bucket("next", importance=9, activation_count=1),
+    ]
+    _install_runtime(buckets, configured_limit)
+    monkeypatch.setattr("tools.breath.surface.random.shuffle", lambda items: None)
+    monkeypatch.setattr("tools.breath.surface.random.random", lambda: 1.0)
+
+    output = await surface_default(
+        max_results=max_results,
+        max_tokens=10000,
+        tag_filter=[],
+    )
+
+    assert _primary_ids(output) == expected_ids
+
+
+@pytest.mark.asyncio
+async def test_zero_cold_start_allows_sampling_to_choose_any_ranked_candidate(
+    monkeypatch,
+):
+    buckets = [
+        _bucket("cold", importance=8, activation_count=0),
+        _bucket("high", importance=10, activation_count=1),
+        _bucket("next", importance=9, activation_count=1),
+        _bucket("low", importance=7, activation_count=1),
+    ]
+    _install_runtime(buckets, 0)
+    rt.config["surfacing"]["sampling"] = {
+        "enabled": True,
+        "top_k": 4,
+        "sample_k": 1,
+        "temperature": 1.0,
+    }
+    monkeypatch.setattr(
+        "tools.breath.surface.random.choices",
+        lambda population, weights, k: [len(population) - 1],
+    )
+    monkeypatch.setattr("tools.breath.surface.random.shuffle", lambda items: None)
+    monkeypatch.setattr("tools.breath.surface.random.random", lambda: 1.0)
+
+    output = await surface_default(
+        max_results=1,
+        max_tokens=10000,
+        tag_filter=[],
+    )
+
+    assert _primary_ids(output) == ["low"]
+
+
+@pytest.mark.asyncio
+async def test_sampling_returns_only_picked_subset_when_max_results_covers_pool(
+    monkeypatch,
+):
+    buckets = [
+        _bucket("rank-1", importance=10, activation_count=1),
+        _bucket("rank-2", importance=9, activation_count=1),
+        _bucket("rank-3", importance=8, activation_count=1),
+        _bucket("rank-4", importance=7, activation_count=1),
+        _bucket("rank-5", importance=6, activation_count=1),
+    ]
+    _install_runtime(buckets, 0)
+    rt.config["surfacing"]["sampling"] = {
+        "enabled": True,
+        "top_k": 5,
+        "sample_k": 2,
+        "temperature": 1.0,
+    }
+    monkeypatch.setattr(
+        "tools.breath.surface.random.choices",
+        lambda population, weights, k: [len(population) - 1],
+    )
+    monkeypatch.setattr("tools.breath.surface.random.shuffle", lambda items: None)
+    monkeypatch.setattr("tools.breath.surface.random.random", lambda: 1.0)
+
+    output = await surface_default(
+        max_results=5,
+        max_tokens=10000,
+        tag_filter=[],
+    )
+
+    assert _primary_ids(output) == ["rank-5", "rank-4"]
+
+
+@pytest.mark.asyncio
+async def test_sampling_never_expands_pool_when_sample_k_exceeds_top_k(
+    monkeypatch,
+):
+    buckets = [
+        _bucket("rank-1", importance=10, activation_count=1),
+        _bucket("rank-2", importance=9, activation_count=1),
+        _bucket("outside-pool", importance=8, activation_count=1),
+    ]
+    _install_runtime(buckets, 0)
+    rt.config["surfacing"]["sampling"] = {
+        "enabled": True,
+        "top_k": 2,
+        "sample_k": 4,
+        "temperature": 1.0,
+    }
+    monkeypatch.setattr(
+        "tools.breath.surface.random.choices",
+        lambda population, weights, k: [len(population) - 1],
+    )
+    monkeypatch.setattr("tools.breath.surface.random.shuffle", lambda items: None)
+    monkeypatch.setattr("tools.breath.surface.random.random", lambda: 1.0)
+
+    output = await surface_default(
+        max_results=5,
+        max_tokens=10000,
+        tag_filter=[],
+    )
+
+    assert _primary_ids(output) == ["rank-2", "rank-1"]
+    assert "bucket_id:outside-pool" not in output
+
+
+@pytest.mark.asyncio
+async def test_zero_cold_start_does_not_reinsert_unvisited_bucket_as_passive(
+    monkeypatch,
+):
+    buckets = [
+        _bucket("cold", importance=8, activation_count=0),
+        _bucket("high", importance=10, activation_count=1),
+    ]
+    _install_runtime(buckets, 0)
+    monkeypatch.setattr("tools.breath.surface.random.shuffle", lambda items: None)
+    monkeypatch.setattr("tools.breath.surface.random.random", lambda: 1.0)
+
+    output = await surface_default(
+        max_results=1,
+        max_tokens=10000,
+        tag_filter=[],
+    )
+
+    assert _primary_ids(output) == ["high"]
+    assert "bucket_id:cold" not in output
+
+
+@pytest.mark.parametrize("invalid_limit", [True, 1.5, -1, 3])
+@pytest.mark.asyncio
+async def test_invalid_cold_start_limit_falls_back_to_two(
+    monkeypatch,
+    invalid_limit,
+):
+    buckets = [
+        _bucket("cold-a", importance=8, activation_count=0),
+        _bucket("cold-b", importance=8, activation_count=0),
+        _bucket("high", importance=10, activation_count=1),
+    ]
+    _install_runtime(buckets, invalid_limit)
+    monkeypatch.setattr("tools.breath.surface.random.shuffle", lambda items: None)
+    monkeypatch.setattr("tools.breath.surface.random.random", lambda: 1.0)
+
+    output = await surface_default(
+        max_results=3,
+        max_tokens=10000,
+        tag_filter=[],
+    )
+
+    assert _primary_ids(output) == ["cold-a", "cold-b", "high"]

--- a/tests/test_dashboard_env_config_contract.py
+++ b/tests/test_dashboard_env_config_contract.py
@@ -113,7 +113,22 @@ def test_main_config_load_and_save_preserve_valid_zero_values():
 
     assert "cfg.dehydration.temperature != null" in load_source
     assert "cfg.merge_threshold != null" in load_source
+    assert "sf.cold_start_max_results != null" in load_source
     assert "Number.isFinite(dehyTemperature) ? dehyTemperature : 0.1" in save_source
     assert "Number.isFinite(mergeThreshold) ? mergeThreshold : 75" in save_source
+    assert "coldStartRaw === '' ? 2 : coldStartMaxResults" in save_source
+    assert "coldStartRaw !== ''" in save_source
+    assert "!Number.isInteger(coldStartMaxResults)" in save_source
+    assert "coldStartMaxResults < 0" in save_source
+    assert "coldStartMaxResults > 2" in save_source
     assert "parseFloat(document.getElementById('cfg-dehy-temp').value) || 0.1" not in save_source
     assert "parseInt(document.getElementById('cfg-merge').value) || 75" not in save_source
+    assert "cold_start_max_results: parseInt" not in save_source
+
+
+def test_sampling_preview_is_labeled_as_score_only_not_random_breath():
+    html = DASHBOARD.read_text(encoding="utf-8")
+
+    assert 'onclick="previewBreathScores()"' in html
+    assert "当前评分前五（不是随机 breath 结果）" in html
+    assert "testSamplingBreath" not in html

--- a/tests/test_priority4_confusion_cleanup.py
+++ b/tests/test_priority4_confusion_cleanup.py
@@ -933,6 +933,10 @@ def test_mcp_token_regenerate_serializes_disk_and_runtime_commit_across_loops(
         {"surfacing": {"breath_max_tokens": 499}},
         {"surfacing": {"breath_max_tokens": 40001}},
         {"surfacing": {"feel_max_tokens": 20001}},
+        {"surfacing": {"cold_start_max_results": -1}},
+        {"surfacing": {"cold_start_max_results": 3}},
+        {"surfacing": {"cold_start_max_results": True}},
+        {"surfacing": {"cold_start_max_results": 1.5}},
         {"surfacing": {"sampling": {"top_k": 0}}},
         {"surfacing": {"sampling": {"sample_k": 21}}},
         {"surfacing": {"sampling": {"temperature": float("nan")}}},
@@ -997,6 +1001,7 @@ async def test_dashboard_config_persists_validated_numeric_types(monkeypatch):
                     "breath_max_results": "11",
                     "breath_max_tokens": "35000",
                     "feel_max_tokens": "7000",
+                    "cold_start_max_results": "0",
                     "sampling": {
                         "enabled": True,
                         "top_k": "9",
@@ -1016,6 +1021,7 @@ async def test_dashboard_config_persists_validated_numeric_types(monkeypatch):
         "breath_max_results": 11,
         "breath_max_tokens": 35000,
         "feel_max_tokens": 7000,
+        "cold_start_max_results": 0,
     }
     assert persisted["merge_threshold"] == 42
     assert persisted["host_port"] == 8123
@@ -1023,6 +1029,7 @@ async def test_dashboard_config_persists_validated_numeric_types(monkeypatch):
         "breath_max_results": 11,
         "breath_max_tokens": 35000,
         "feel_max_tokens": 7000,
+        "cold_start_max_results": 0,
         "sampling": {
             "enabled": True,
             "top_k": 9,
@@ -1030,6 +1037,14 @@ async def test_dashboard_config_persists_validated_numeric_types(monkeypatch):
             "temperature": 0.8,
         },
     }
+
+    monkeypatch.setattr(
+        config_api,
+        "read_config_yaml",
+        lambda: copy.deepcopy(persisted),
+    )
+    runtime_view = await mcp.routes[("GET", "/api/config")](JsonRequest(method="GET"))
+    assert _json(runtime_view)["surfacing"]["cold_start_max_results"] == 0
 
 
 @pytest.mark.asyncio

--- a/tests/test_web_api_docker_integration.py
+++ b/tests/test_web_api_docker_integration.py
@@ -112,11 +112,20 @@ def test_desktop_management_api_first_run_and_authenticated_flow():
 
         config_update = client.post(
             "/api/config",
-            json={"surfacing": {"breath_max_results": 11}, "persist": False},
+            json={
+                "surfacing": {
+                    "breath_max_results": 11,
+                    "cold_start_max_results": 0,
+                },
+                "persist": False,
+            },
         )
         assert config_update.status_code == 200
         assert "surfacing.breath_max_results" in config_update.json()["updated"]
-        assert client.get("/api/config").json()["surfacing"]["breath_max_results"] == 11
+        assert "surfacing.cold_start_max_results" in config_update.json()["updated"]
+        surfacing_config = client.get("/api/config").json()["surfacing"]
+        assert surfacing_config["breath_max_results"] == 11
+        assert surfacing_config["cold_start_max_results"] == 0
 
         status = client.get("/api/status")
         assert status.status_code == 200

--- a/update_manifest.json
+++ b/update_manifest.json
@@ -7,8 +7,8 @@
     },
     {
       "path": "frontend/dashboard.html",
-      "sha256": "840fd05b06fb03f8914d3020a8eea8e814108d001444c3ce677fe00368056284",
-      "size": 534925
+      "sha256": "67bb1c9518f02f6f257b3ea6b466e9d4e608e23aa0aee5df379ed37cbdafa647",
+      "size": 536007
     },
     {
       "path": "frontend/favicon.svg",
@@ -832,8 +832,8 @@
     },
     {
       "path": "src/tools/breath/surface.py",
-      "sha256": "b0cde79cd74a2fbb7e20a2190359b600f2ac8e70507b5a3fafaa88fdca027942",
-      "size": 20647
+      "sha256": "95b9dca777cebe9c229072f585479ee6589ca51a7d242dd78d8792e605fc483a",
+      "size": 21838
     },
     {
       "path": "src/tools/dream/__init__.py",
@@ -952,13 +952,13 @@
     },
     {
       "path": "src/web/buckets.py",
-      "sha256": "dc274b205d6e47d51eb4e13747c811d67b4f97f12ad9e2a6e853944afabc34d0",
-      "size": 50062
+      "sha256": "2d3de45dd042acab31c6bdf02322dee69e027925c6964399a4d31ea33fc21976",
+      "size": 49928
     },
     {
       "path": "src/web/config_api.py",
-      "sha256": "e7ae32b90ab3e6cd325d66b37ba1c458d9fcf72e218a0f43acb144cf33bb852b",
-      "size": 73746
+      "sha256": "a85291a26ada5078007e24c61efd63d2d79018cb307542787486345483846c1f",
+      "size": 74342
     },
     {
       "path": "src/web/dashboard.py",


### PR DESCRIPTION
## Summary

- add `surfacing.cold_start_max_results` (0–2) so operators can remove forced cold-start slots; `0` also disables unvisited-only passive surfacing while keeping those buckets as normal candidates
- make enabled sampling return only the weighted subset selected from the first `top_k` candidates, rather than the same fixed top set in a different order
- expose and persist the setting in Dashboard/config APIs, clarify the score-only preview, and update public/internal docs
- add regression coverage for zero/default/invalid cold-start values, production-shaped sampling, pool bounds, persistence, and Dashboard contracts

## Validation

- `python -m pytest` on 16 Breath/config regression modules: **179 passed, 1 skipped**
- `git diff --check origin/main...HEAD`