### PR TITLE
feat(plan): add optional time window fields

### DIFF
--- a/src/bucket_manager.py
+++ b/src/bucket_manager.py
@@ -449,6 +449,8 @@ _METADATA_TEXT_LIMITS = {
     "resolution_reason": 500,
     "resolved_by": 128,
     "related_bucket": 128,
+    "window_start": 64,
+    "window_end": 64,
     "author": 120,
     "user_name": 120,
     "title": 120,
@@ -2546,7 +2548,7 @@ class BucketManager:
         # 由 server.py 的 plan() / trace() / /api/plans/{id}/action 维护，bucket_manager 不参与生成。
         for k in ("status", "type", "resolution_reason", "resolved_by",
                   "resolution_suggested",
-                  "related_bucket", "author", "user_name", "letter_date",
+                  "related_bucket", "window_start", "window_end", "author", "user_name", "letter_date",
                   "lock_type", "unlock_date", "locked_by", "lock_owner_source", "writer_name",
                   "change_log",
                   # iter 1.8 新增字段。除 weight 外全部透传不转换。

--- a/src/server.py
+++ b/src/server.py
@@ -1139,18 +1139,22 @@ async def plan(
     related_bucket: Optional[str] = "",
     weight: Optional[float] = 0.5,
     why_remembered: Optional[str] = "",
+    window_start: Optional[str] = "",
+    window_end: Optional[str] = "",
 ) -> str:
-    """登记一个待办/承诺/未闭环事项。status=active(默认)/resolved/abandoned。related_bucket 可选,关联到某个普通记忆桶。weight=承诺重量 0.0-1.0(默认 0.5),与 importance 区分——importance 表示「多重要」、weight 表示「多重」。why_remembered=登记原因(可选、仅展示)。plan 不衰减、不出现在普通 breath,仅在 dream 末尾的 active 段返回;后续 hold/grow 写入新事件时系统只会提示可能已完成,实际关闭必须显式调用 trace(status="resolved")。"""
+    """登记一个待办/承诺/未闭环事项。status=active(默认)/resolved/abandoned。related_bucket 可选,关联到某个普通记忆桶。weight=承诺重量 0.0-1.0(默认 0.5),与 importance 区分——importance 表示「多重要」、weight 表示「多重」。why_remembered=登记原因(可选、仅展示)。window_start/window_end 为可选时间窗,接受 YYYY-MM-DD 或 ISO 8601；未写时区按 config timezone。plan 不衰减、不出现在普通 breath,仅在 dream 末尾的 active 段返回;后续 hold/grow 写入新事件时系统只会提示可能已完成,实际关闭必须显式调用 trace(status="resolved")。"""
     return await _with_notice(
         _t_plan.plan_create(
             content=content, status=status, related_bucket=related_bucket,
             weight=weight, why_remembered=why_remembered,
+            window_start=window_start, window_end=window_end,
         ),
         op="plan",
         args={
             "content_len": len(content or ""), "status": status,
             "related_bucket": related_bucket, "weight": weight,
             "why_len": len(why_remembered or ""),
+            "window_start": window_start, "window_end": window_end,
         },
     )
 

--- a/src/tools/plan/core.py
+++ b/src/tools/plan/core.py
@@ -9,7 +9,7 @@ breath 中。
 
 关键行为：
 - plan_create：去重（同正文 + status=active 已存在 → 直接返回原 ID），
-  写入 type=plan + status + weight + change_log 起点
+  写入 type=plan + status + weight + 时间窗 + change_log 起点
 - letter_write：原文永久保存，author 接受任意字符串署名（"ai" 或等于
   ai_name 时统一存为 ai_name 的值，其它字符串原样存为署名；"user" 为
   用户侧），写入 type=letter + author/title/letter_date 元数据
@@ -26,6 +26,7 @@ breath 中。
 
 import json
 import math
+import re
 from datetime import datetime, timezone
 from typing import Optional
 
@@ -55,6 +56,41 @@ _GENERIC_RELATION_NAMES = {
 }
 _HUMAN_AUTHOR_ALIASES = {"user", "human", "human-side"}
 _AI_AUTHOR_ALIASES = {"ai", "ai-side", "claude"}
+_DATE_ONLY_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+def normalize_plan_window(value: object, *, boundary: str) -> str | None:
+    """把 Plan 时间窗边界归一化为带 offset 的 ISO 8601。"""
+    raw = str(value or "").strip()
+    if not raw:
+        return None
+    try:
+        parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except (TypeError, ValueError) as exc:
+        raise ToolInputError(
+            f"时间窗「{raw}」看不懂。需要 YYYY-MM-DD 或 ISO 8601，"
+            "例如 2026-09-02 或 2026-09-02T09:30:00+08:00。"
+        ) from exc
+    if _DATE_ONLY_RE.fullmatch(raw) and boundary == "end":
+        parsed = parsed.replace(hour=23, minute=59, second=59, microsecond=999999)
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        parsed = parsed.replace(tzinfo=get_tzinfo())
+    return parsed.isoformat()
+
+
+def _window_instant(value: object) -> str | None:
+    raw = str(value or "").strip()
+    if not raw:
+        return None
+    try:
+        parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+        if parsed.tzinfo is None or parsed.utcoffset() is None:
+            parsed = parsed.replace(tzinfo=get_tzinfo())
+        return parsed.astimezone(timezone.utc).isoformat()
+    except (TypeError, ValueError):
+        return raw
+
+
 
 
 def normalize_unlock_date(lock_type: str, value: object, *, now: datetime | None = None) -> str | None:
@@ -193,6 +229,8 @@ async def plan_create(
     related_bucket: Optional[str] = "",
     weight: Optional[float] = 0.5,
     why_remembered: Optional[str] = "",
+    window_start: Optional[str] = "",
+    window_end: Optional[str] = "",
 ) -> str:
     if status is None:
         status = "active"
@@ -210,6 +248,14 @@ async def plan_create(
         parsed_weight = 0.5
     weight = max(0.0, min(1.0, parsed_weight))
     why_remembered = str(why_remembered).strip()[:500]
+    normalized_start = normalize_plan_window(window_start, boundary="start")
+    normalized_end = normalize_plan_window(window_end, boundary="end")
+    if (
+        normalized_start
+        and normalized_end
+        and _window_instant(normalized_start) > _window_instant(normalized_end)
+    ):
+        raise ToolInputError("window_start 不能晚于 window_end。")
     await rt.decay_engine.ensure_started()
     if not content or not content.strip():
         raise ToolInputError("内容为空，无法登记计划。")
@@ -220,6 +266,8 @@ async def plan_create(
         status=status,
         related_bucket=related_bucket,
         why_remembered=why_remembered,
+        window_start=normalized_start or "",
+        window_end=normalized_end or "",
     )
     if metadata_err:
         raise ToolInputError(metadata_err)
@@ -260,10 +308,14 @@ async def plan_create(
     update_kwargs = {"status": status, "change_log": initial_log}
     if related_bucket.strip():
         update_kwargs["related_bucket"] = related_bucket.strip()
+    if normalized_start:
+        update_kwargs["window_start"] = normalized_start
+    if normalized_end:
+        update_kwargs["window_end"] = normalized_end
     try:
         await rt.bucket_mgr.update(bucket_id, **update_kwargs)
     except Exception as e:
-        rt.logger.warning(f"plan() failed to set status/related: {e}")
+        rt.logger.warning(f"plan() failed to set status/related/window: {e}")
     # 注意：bucket_mgr.create() 已在 content 落盘后投递 embedding outbox
     # 向量，这里不需要也不应该重复调用 generate_and_store（见 hold/feel.py 同类注释）。
     return f"📋plan→{bucket_id} [{status}]"

--- a/tests/test_breath_plan_channel.py
+++ b/tests/test_breath_plan_channel.py
@@ -7,12 +7,15 @@ catalog 模式和「有 query 的检索模式」里生效。`breath_advanced(dom
 降级成只报条数，plan 的正文一度没有任何读取入口。
 """
 
+from datetime import timedelta, timezone
 from unittest.mock import MagicMock
 
 import pytest
 
 import tools._runtime as rt
+from errors import ToolInputError
 from tools.breath import dispatch
+from tools.plan.core import normalize_plan_window, plan_create
 
 
 class _NoopDecay:
@@ -43,6 +46,89 @@ def _install_runtime(bucket_mgr):
     rt.record_v3_tool_event = lambda *_args, **_kwargs: None
 
 
+def _created_id(result: str) -> str:
+    return result.split("→", 1)[1].split(" ", 1)[0].split("（", 1)[0]
+
+
+@pytest.mark.asyncio
+async def test_plan_mcp_schema_exposes_optional_window_fields():
+    import server
+
+    listed = next(tool for tool in await server.mcp.list_tools() if tool.name == "plan")
+    schema = listed.inputSchema
+
+    assert set(schema["properties"]) == {
+        "content",
+        "status",
+        "related_bucket",
+        "weight",
+        "why_remembered",
+        "window_start",
+        "window_end",
+    }
+    assert schema["required"] == ["content"]
+
+
+def test_plan_window_dates_expand_to_configured_local_day(monkeypatch):
+    import tools.plan.core as core
+
+    local_tz = timezone(timedelta(hours=8))
+    monkeypatch.setattr(core, "get_tzinfo", lambda: local_tz)
+
+    assert normalize_plan_window("2026-09-02", boundary="start") == (
+        "2026-09-02T00:00:00+08:00"
+    )
+    assert normalize_plan_window("2026-09-02", boundary="end") == (
+        "2026-09-02T23:59:59.999999+08:00"
+    )
+    assert normalize_plan_window(
+        "2026-09-02T09:30:00", boundary="start"
+    ) == "2026-09-02T09:30:00+08:00"
+
+
+def test_plan_window_preserves_explicit_offset_and_accepts_z():
+    assert normalize_plan_window(
+        "2026-09-02T09:30:00+09:00", boundary="start"
+    ) == "2026-09-02T09:30:00+09:00"
+    assert normalize_plan_window(
+        "2026-09-02T00:30:00Z", boundary="end"
+    ) == "2026-09-02T00:30:00+00:00"
+
+
+@pytest.mark.parametrize("value", ["tomorrow", "2026-02-30", "2026-09-02 garbage"])
+def test_plan_window_rejects_values_outside_the_contract(value):
+    with pytest.raises(ToolInputError, match="YYYY-MM-DD|ISO 8601"):
+        normalize_plan_window(value, boundary="start")
+
+
+@pytest.mark.asyncio
+async def test_plan_reversed_window_compares_real_instants(bucket_mgr):
+    _install_runtime(bucket_mgr)
+
+    with pytest.raises(ToolInputError, match="window_start.*window_end"):
+        await plan_create(
+            "offset order",
+            window_start="2026-09-02T09:00:00+08:00",
+            window_end="2026-09-02T00:30:00Z",
+        )
+
+    assert await bucket_mgr.list_all(include_archive=False) == []
+
+
+@pytest.mark.asyncio
+async def test_plan_single_ended_past_window_is_persisted(bucket_mgr):
+    _install_runtime(bucket_mgr)
+
+    result = await plan_create("past plan", window_end="2020-01-01")
+    bucket = await bucket_mgr.get(_created_id(result))
+
+    assert bucket["metadata"]["status"] == "active"
+    assert bucket["metadata"]["window_end"] == "2020-01-01T23:59:59.999999+08:00"
+    assert "window_start" not in bucket["metadata"]
+    assert bucket["metadata"]["change_log"][0]["action"] == "created"
+
+
+@pytest.mark.asyncio
 async def _make_plan(bucket_mgr, content: str, status: str = "active") -> str:
     bucket_id = await bucket_mgr.create(
         content=content,

--- a/tests/test_mcp_tools_docker_integration.py
+++ b/tests/test_mcp_tools_docker_integration.py
@@ -151,7 +151,10 @@ EXPECTED_TOOL_PROPERTIES = {
     "anchor": {"bucket_id"},
     "release": {"bucket_id"},
     "pulse": {"include_archive"},
-    "plan": {"content", "status", "related_bucket", "weight", "why_remembered"},
+    "plan": {
+        "content", "status", "related_bucket", "weight", "why_remembered",
+        "window_start", "window_end",
+    },
     "letter_write": {
         "author", "content", "user_name", "title", "date", "ai_name",
         "lock_type", "unlock_date",

--- a/update_manifest.json
+++ b/update_manifest.json
@@ -42,8 +42,8 @@
     },
     {
       "path": "src/bucket_manager.py",
-      "sha256": "232554acf2345fd8a35f240a45ae36467d57fbe199e6556a9bae3bd8477c6d45",
-      "size": 192172
+      "sha256": "2d1a7fd810a79c2cb13a2a1d6ac923dd4791d0f6e17b2ed7b8007900683e1164",
+      "size": 192247
     },
     {
       "path": "src/decay_engine.py",
@@ -557,8 +557,8 @@
     },
     {
       "path": "src/server.py",
-      "sha256": "02107c88da366840c08b98bf8493910c57fb01f7cede781d431d187c914b83ed",
-      "size": 80622
+      "sha256": "7ffe36dfb23d3aa2fb63b34073b8818d4d419f2511506c4836c657c2505fd354",
+      "size": 80936
     },
     {
       "path": "src/server_app.py",
@@ -722,8 +722,8 @@
     },
     {
       "path": "src/tools/plan/core.py",
-      "sha256": "785b2788f4528de882506754db5cbcc15b34032d9cb030acc8f96c3b7ee88e1a",
-      "size": 23184
+      "sha256": "2a4298300b7e0c8b656daaef36e58e18b5289b21881296eb12e25f0512f559fd",
+      "size": 25207
     },
     {
       "path": "src/tools/them/__init__.py",


### PR DESCRIPTION
## 改了什么

为 Plan MCP 增加可选的 `window_start` / `window_end` 时间窗字段。

- 支持 `YYYY-MM-DD` 和 ISO 8601
- 未指定时区时按 config timezone 归一化
- 仅填写日期时，`window_end` 归一化到当天末尾
- 校验 `window_start` 不晚于 `window_end`
- 支持只填写单侧时间窗并持久化
- 保持现有 Plan status 与正文去重语义不变

## 为什么这么改

有些 Plan 仍然有效，但只在未来某个时间段相关。首版先给 Plan 增加独立的时间窗表达能力，不新增 status，也不在本次改动中加入自动 resurfacing / 过期处理等行为，避免扩大 Plan 现有语义和本次改动范围。

## 测试没有

- `python -m pytest -q tests/test_breath_plan_channel.py` → 12 passed
- 3.6.13 schema regression tests → 9 passed
- `git diff --check` → clean

---

- [x] 我的提交都带了 `Signed-off-by:`（`git commit -s`），表示我有权提交这些代码
- [x] 没有把真实记忆内容、API Key、密码带进这个 PR